### PR TITLE
[BYOB-47] 카카오 OpenAPI 분석 및 연동

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@ build/
 !**/src/main/**/build/
 !**/src/test/**/build/
 
+
+
 ### STS ###
 .apt_generated
 .classpath
@@ -35,3 +37,7 @@ out/
 
 ### VS Code ###
 .vscode/
+
+### Custom ###
+# Ignore properties files
+*.properties

--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,7 @@ repositories {
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
+	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.h2database:h2'

--- a/build.gradle
+++ b/build.gradle
@@ -24,13 +24,13 @@ repositories {
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+//	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	compileOnly 'org.projectlombok:lombok'
-	runtimeOnly 'com.h2database:h2'
-	runtimeOnly 'com.mysql:mysql-connector-j'
+//	runtimeOnly 'com.h2database:h2'
+//	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'

--- a/src/main/java/team_alcoholic/jumo_server/auth/dto/KakaoResponse.java
+++ b/src/main/java/team_alcoholic/jumo_server/auth/dto/KakaoResponse.java
@@ -1,0 +1,59 @@
+package team_alcoholic.jumo_server.auth.dto;
+
+import lombok.RequiredArgsConstructor;
+
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * 카카오 OAuth2 인증을 통해 받은 사용자 정보를 담는 DTO
+ * Optional을 사용하여 NullPointer 예외를 방지
+ */
+@RequiredArgsConstructor
+public class KakaoResponse implements OAuth2Response {
+
+    private final Map<String, Object> attributes;
+
+    @Override
+    public String getProvider() {
+        return "kakao";
+    }
+
+    @Override
+    public String getProviderId() {
+        return Optional.ofNullable(attributes.get("id"))
+                .map(Object::toString)
+                .orElse(null);
+    }
+
+    @Override
+    public String getProfileNickname() {
+        return Optional.ofNullable(attributes.get("properties"))
+                .map(properties -> (Map<String, Object>) properties)
+                .map(properties -> properties.get("nickname"))
+                .map(Object::toString)
+                .orElse(null);
+    }
+
+    @Override
+    public String getProfileImage() {
+        return Optional.ofNullable(attributes.get("kakao_account"))
+                .map(kakaoAccount -> (Map<String, Object>) kakaoAccount)
+                .map(kakaoAccount -> kakaoAccount.get("profile"))
+                .map(profile -> (Map<String, Object>) profile)
+                .map(profile -> profile.get("profile_image_url"))
+                .map(Object::toString)
+                .orElse(null);
+    }
+
+    @Override
+    public String getProfileThumbnailImage() {
+        return Optional.ofNullable(attributes.get("properties"))
+                .map(properties -> (Map<String, Object>) properties)
+                .map(properties -> properties.get("thumbnail_image"))
+                .map(Object::toString)
+                .orElse(null);
+    }
+
+
+}

--- a/src/main/java/team_alcoholic/jumo_server/auth/dto/OAuth2Response.java
+++ b/src/main/java/team_alcoholic/jumo_server/auth/dto/OAuth2Response.java
@@ -1,0 +1,15 @@
+package team_alcoholic.jumo_server.auth.dto;
+
+/**
+ * OAuth2 인증을 통해 받은 사용자 정보를 담는 DTO 인터페이스
+
+ */
+public interface OAuth2Response {
+
+    String getProvider();
+    String getProviderId();
+    String getProfileNickname();
+    String getProfileImage();
+    String getProfileThumbnailImage();
+
+}

--- a/src/main/java/team_alcoholic/jumo_server/auth/dto/OAuth2UserPrincipal.java
+++ b/src/main/java/team_alcoholic/jumo_server/auth/dto/OAuth2UserPrincipal.java
@@ -1,0 +1,52 @@
+package team_alcoholic.jumo_server.auth.dto;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+import java.util.*;
+
+/**
+ * OAuth2User 인터페이스를 구현한 클래스
+ * 세션에 담기는 사용자 정보를 담는 DTO
+ */
+@RequiredArgsConstructor
+public class OAuth2UserPrincipal implements OAuth2User {
+
+    private final OAuth2Response oAuth2Response;
+
+    /**
+     * 사용자 속성을 반환하는 메소드
+     * @return 사용자 속성을 포함하는 Map 객체
+     */
+    @Override
+    public Map<String, Object> getAttributes() {
+        Map<String, Object> attributes = new HashMap<>();
+        attributes.put("provider", oAuth2Response.getProvider());
+        attributes.put("providerId", oAuth2Response.getProviderId());
+        attributes.put("profileNickname", oAuth2Response.getProfileNickname());
+        attributes.put("profileImage", oAuth2Response.getProfileImage());
+        attributes.put("profileThumbnailImage", oAuth2Response.getProfileThumbnailImage());
+        return attributes;
+    }
+
+    /**
+     * 사용자 권한을 반환하는 메소드 -> 필수로 있어야 하는 메소드
+     * 현재 권한 설정은 하지 않음
+     * @return 빈 컬렉션
+     */
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return Collections.emptyList();
+    }
+
+    /**
+     * 사용자의 고유 식별자를 반환하는 메소드 -> 필수로 있어야 하는 메소드
+     * @return provider+" "+providerId
+     */
+    @Override
+    public String getName() {
+        return oAuth2Response.getProvider() + " " + oAuth2Response.getProviderId();
+    }
+
+}

--- a/src/main/java/team_alcoholic/jumo_server/auth/service/OAuth2UserService.java
+++ b/src/main/java/team_alcoholic/jumo_server/auth/service/OAuth2UserService.java
@@ -1,0 +1,33 @@
+package team_alcoholic.jumo_server.auth.service;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+import team_alcoholic.jumo_server.auth.dto.KakaoResponse;
+import team_alcoholic.jumo_server.auth.dto.OAuth2Response;
+import team_alcoholic.jumo_server.auth.dto.OAuth2UserPrincipal;
+
+@Slf4j
+@Service
+public class OAuth2UserService extends DefaultOAuth2UserService {
+
+    @Override
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+        OAuth2User oAuth2User = super.loadUser(userRequest);
+        String registrationId = userRequest.getClientRegistration().getRegistrationId();
+
+        OAuth2Response oAuth2Response;
+        switch (registrationId) {
+            case "kakao":
+                oAuth2Response = new KakaoResponse(oAuth2User.getAttributes());
+                break;
+            default:
+                throw new OAuth2AuthenticationException("Unsupported login provider: " + registrationId);
+        }
+
+        return new OAuth2UserPrincipal(oAuth2Response);
+    }
+}

--- a/src/main/java/team_alcoholic/jumo_server/config/SecurityConfig.java
+++ b/src/main/java/team_alcoholic/jumo_server/config/SecurityConfig.java
@@ -2,6 +2,7 @@ package team_alcoholic.jumo_server.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.web.SecurityFilterChain;
@@ -14,12 +15,21 @@ public class SecurityConfig {
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
 
         http
+                .csrf((csrf) -> csrf.disable());
+
+        http
+                .formLogin((login) -> login.disable());
+
+        http
+                .httpBasic((basic) -> basic.disable());
+
+        http
+                .oauth2Login(Customizer.withDefaults());
+
+        http
                 .authorizeHttpRequests((auth) -> auth
-                                .requestMatchers("**", "/login").permitAll()
-//                        .requestMatchers("/admin").hasRole("ADMIN")
-//                        .requestMatchers("/my/**").hasAnyRole("ADMIN", "USER")
-                                .anyRequest().authenticated()
-                );
+                        .requestMatchers("/", "/oauth2/**", "/login/**").permitAll()
+                        .anyRequest().authenticated());
 
         return http.build();
     }

--- a/src/main/java/team_alcoholic/jumo_server/config/SecurityConfig.java
+++ b/src/main/java/team_alcoholic/jumo_server/config/SecurityConfig.java
@@ -2,11 +2,16 @@ package team_alcoholic.jumo_server.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.security.config.Customizer;
+import org.springframework.http.HttpStatus;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.HttpStatusEntryPoint;
+import team_alcoholic.jumo_server.auth.service.OAuth2UserService;
 
+/**
+ * Spring Security 설정 클래스
+ */
 @Configuration
 @EnableWebSecurity
 public class SecurityConfig {
@@ -14,22 +19,26 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
 
+        /*
+
+         */
         http
-                .csrf((csrf) -> csrf.disable());
+                .csrf(csrf -> csrf.disable())
+                .formLogin(login -> login.disable())
+                .httpBasic(basic -> basic.disable())
+                .oauth2Login((oauth2) -> oauth2
+                        .userInfoEndpoint((userInfoEndpointConfig) -> userInfoEndpointConfig
+                                .userService(new OAuth2UserService())
+                        )
+                );
 
         http
-                .formLogin((login) -> login.disable());
-
-        http
-                .httpBasic((basic) -> basic.disable());
-
-        http
-                .oauth2Login(Customizer.withDefaults());
-
-        http
-                .authorizeHttpRequests((auth) -> auth
+                .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/", "/oauth2/**", "/login/**").permitAll()
                         .anyRequest().authenticated());
+//                .exceptionHandling(exceptionHandling -> exceptionHandling
+//                        .authenticationEntryPoint(new HttpStatusEntryPoint(HttpStatus.UNAUTHORIZED))
+//                );
 
         return http.build();
     }


### PR DESCRIPTION
## 🚀 완료한 기능 혹은 수정 기능
**Jira 티켓: [BYOB-47]**


<br>

## 🔨 작업 사항 

- 개발자 유미 스프링 OAuth2 클라이언트 세션를 참고하여 개발
- https://www.youtube.com/watch?v=ulb4eNSqCPs&list=PLJkjrxxiBSFBGk0b931ZkCVlNUo7sFisu&index=1
- 스프링 세큐리티 설정
- 카카오 로그인 연동

### 기본적인 플로우
- oauth2로부터 엑세스토큰 발급 받는 과정까지 스프링 세큐리티 기본 설정 사용 (별도의 controller,service 구현 x, application.properties만 설정)
- 리소스 서버로부터 유저 정보 받고 이를 세션으로 등록하는 과정은 OAuth2UserService로 처리
- 유저 정보를 받아서 이를 Response DTO로 처리후, OAuth2UserPrincipal DTO를 사용해 세션에 등록

## 문제 및 해결
### [invalid_token_response] 문제 
- 인증 서버로부터 엑세스 토큰 잘 받아왔지만 리소스 서버에서 사용자 정보를 가져오는 과정에서 invalid_token_response문제가 발생함
- <img width="579" alt="스크린샷 2024-07-09 오후 9 54 55" src="https://github.com/team-alcoholic/jumo-server/assets/51476641/b90f311b-03c6-4c14-92c8-249ed33337e6">

- gpt4o, claude 모두 해결 못함

### [invalid_token_response] 해결
- 구글 검색을 통해 해결함
- https://developing-mango.tistory.com/26
- 카카오 로그인은 다음과 같은 세팅을 추가로 해야함
- spring.security.oauth2.client.registration.kakao.client-authentication-method=client_secret_post




[BYOB-47]: https://swm-alcoholic.atlassian.net/browse/BYOB-47?atlOrigin=eyJpIjoiM2E4ZTkyNGVmOTM1NDVmZmFkMjdkNmJjMzJkMjA4MjAiLCJwIjoiaiJ9
