### PR TITLE
[BYOB-48] 회원가입 API + 사용자 DB

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ repositories {
 }
 
 dependencies {
-//	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 	implementation 'org.springframework.boot:spring-boot-starter-web'

--- a/src/main/java/team_alcoholic/jumo_server/auth/dto/CustomOAuth2User.java
+++ b/src/main/java/team_alcoholic/jumo_server/auth/dto/CustomOAuth2User.java
@@ -3,17 +3,17 @@ package team_alcoholic.jumo_server.auth.dto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.oauth2.core.user.OAuth2User;
+import team_alcoholic.jumo_server.user.dto.UserDTO;
 
 import java.util.*;
 
 /**
- * OAuth2User 인터페이스를 구현한 클래스
  * 세션에 담기는 사용자 정보를 담는 DTO
  */
 @RequiredArgsConstructor
-public class OAuth2UserPrincipal implements OAuth2User {
+public class CustomOAuth2User implements OAuth2User {
 
-    private final OAuth2Response oAuth2Response;
+    private final UserDTO userDTO;
 
     /**
      * 사용자 속성을 반환하는 메소드
@@ -22,11 +22,11 @@ public class OAuth2UserPrincipal implements OAuth2User {
     @Override
     public Map<String, Object> getAttributes() {
         Map<String, Object> attributes = new HashMap<>();
-        attributes.put("provider", oAuth2Response.getProvider());
-        attributes.put("providerId", oAuth2Response.getProviderId());
-        attributes.put("profileNickname", oAuth2Response.getProfileNickname());
-        attributes.put("profileImage", oAuth2Response.getProfileImage());
-        attributes.put("profileThumbnailImage", oAuth2Response.getProfileThumbnailImage());
+        attributes.put("provider", userDTO.getProvider());
+        attributes.put("providerId", userDTO.getProviderId());
+        attributes.put("profileNickname", userDTO.getProfileNickname());
+        attributes.put("profileImage", userDTO.getProfileImage());
+        attributes.put("profileThumbnailImage", userDTO.getProfileThumbnailImage());
         return attributes;
     }
 
@@ -46,7 +46,7 @@ public class OAuth2UserPrincipal implements OAuth2User {
      */
     @Override
     public String getName() {
-        return oAuth2Response.getProvider() + " " + oAuth2Response.getProviderId();
+        return userDTO.getProvider() + " " + userDTO.getProviderId();
     }
 
 }

--- a/src/main/java/team_alcoholic/jumo_server/auth/service/OAuth2UserService.java
+++ b/src/main/java/team_alcoholic/jumo_server/auth/service/OAuth2UserService.java
@@ -1,5 +1,6 @@
 package team_alcoholic.jumo_server.auth.service;
 
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
@@ -8,26 +9,50 @@ import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Service;
 import team_alcoholic.jumo_server.auth.dto.KakaoResponse;
 import team_alcoholic.jumo_server.auth.dto.OAuth2Response;
-import team_alcoholic.jumo_server.auth.dto.OAuth2UserPrincipal;
+import team_alcoholic.jumo_server.auth.dto.CustomOAuth2User;
+import team_alcoholic.jumo_server.user.dto.UserDTO;
+import team_alcoholic.jumo_server.user.service.UserService;
 
+/**
+ * 리소스 서버에서 사용자 정보를 가져와 이를 사용하여 사용자 정보를 조회하거나 생성하고 세션에 등록하는 서비스
+ */
 @Slf4j
 @Service
+@RequiredArgsConstructor
 public class OAuth2UserService extends DefaultOAuth2UserService {
 
+    private final UserService userService;
+
+    /**
+     * OAuth2 사용자 정보를 가져와 사용자 정보를 조회하거나 생성하고 세션에 등록하는 메소드
+     * @param userRequest OAuth2 사용자 요청 객체
+     * @return CustomOAuth2User 객체
+     * @throws OAuth2AuthenticationException 인증 예외 발생 시 던짐
+     */
     @Override
     public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
         OAuth2User oAuth2User = super.loadUser(userRequest);
         String registrationId = userRequest.getClientRegistration().getRegistrationId();
+        log.info("OAuth2 사용자 요청이 수신되었습니다. 등록 ID: {}", registrationId);
+        OAuth2Response oAuth2Response = getOAuth2Response(oAuth2User, registrationId);
+        UserDTO user = userService.getUser(oAuth2Response);
+        return new CustomOAuth2User(user);
+    }
 
-        OAuth2Response oAuth2Response;
+    /**
+     * OAuth2로부터 받은 response를 유저 조회를 위한 OAuth2Response로 변환하는 메소드
+     * 인증 기관마다 response가 다르기 때문에 이를 변환해주는 메소드가 필요함
+     * @param oAuth2User OAuth2 사용자 객체
+     * @param registrationId 제공자 ID (예: kakao)
+     * @return OAuth2Response 객체
+     * @throws OAuth2AuthenticationException 지원되지 않는 로그인 제공자인 경우 예외 발생
+     */
+    private OAuth2Response getOAuth2Response(OAuth2User oAuth2User, String registrationId) {
         switch (registrationId) {
             case "kakao":
-                oAuth2Response = new KakaoResponse(oAuth2User.getAttributes());
-                break;
+                return new KakaoResponse(oAuth2User.getAttributes());
             default:
-                throw new OAuth2AuthenticationException("Unsupported login provider: " + registrationId);
+                throw new OAuth2AuthenticationException("지원되지 않는 로그인 제공자: " + registrationId);
         }
-
-        return new OAuth2UserPrincipal(oAuth2Response);
     }
 }

--- a/src/main/java/team_alcoholic/jumo_server/config/SecurityConfig.java
+++ b/src/main/java/team_alcoholic/jumo_server/config/SecurityConfig.java
@@ -1,20 +1,24 @@
 package team_alcoholic.jumo_server.config;
 
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.http.HttpStatus;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.web.SecurityFilterChain;
-import org.springframework.security.web.authentication.HttpStatusEntryPoint;
+import team_alcoholic.jumo_server.user.repository.UserRepository;
 import team_alcoholic.jumo_server.auth.service.OAuth2UserService;
+import team_alcoholic.jumo_server.user.service.UserService;
 
 /**
  * Spring Security 설정 클래스
  */
 @Configuration
 @EnableWebSecurity
+@RequiredArgsConstructor
 public class SecurityConfig {
+
+    private final OAuth2UserService oAuth2UserService;
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
@@ -28,7 +32,7 @@ public class SecurityConfig {
                 .httpBasic(basic -> basic.disable())
                 .oauth2Login((oauth2) -> oauth2
                         .userInfoEndpoint((userInfoEndpointConfig) -> userInfoEndpointConfig
-                                .userService(new OAuth2UserService())
+                                .userService(oAuth2UserService)
                         )
                 );
 

--- a/src/main/java/team_alcoholic/jumo_server/user/controller/UserController.java
+++ b/src/main/java/team_alcoholic/jumo_server/user/controller/UserController.java
@@ -1,0 +1,28 @@
+package team_alcoholic.jumo_server.user.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import team_alcoholic.jumo_server.user.service.UserService;
+
+import java.util.Map;
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/users")
+public class UserController {
+
+    private final UserService userService;
+
+    /**
+     * 사용자 정보 조회 (임시로 세션에서 들고오도록 함)
+     * @param oAuth2User
+     * @return
+     */
+    @GetMapping()
+    public Map<String, Object> user(@AuthenticationPrincipal OAuth2User oAuth2User){
+        return oAuth2User.getAttributes();
+    }
+}

--- a/src/main/java/team_alcoholic/jumo_server/user/domain/User.java
+++ b/src/main/java/team_alcoholic/jumo_server/user/domain/User.java
@@ -1,0 +1,31 @@
+package team_alcoholic.jumo_server.user.domain;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+import team_alcoholic.jumo_server.auth.dto.OAuth2Response;
+
+
+/**
+ * 사용자 정보를 담는 엔티티 (임시 버전)
+ */
+@Entity
+@Getter
+@Setter
+public class User {
+
+    @Id
+    @GeneratedValue(generator = "auto-increment")
+    private Long id;
+
+    private String provider;
+    private String providerId;
+    private String profileNickname;
+    private String profileImage;
+    private String profileThumbnailImage;
+
+
+}

--- a/src/main/java/team_alcoholic/jumo_server/user/dto/UserDTO.java
+++ b/src/main/java/team_alcoholic/jumo_server/user/dto/UserDTO.java
@@ -1,0 +1,20 @@
+package team_alcoholic.jumo_server.user.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * 사용자 정보를 담는 DTO
+ */
+@Getter
+@Setter
+@Builder
+public class UserDTO {
+    private Long id;
+    private String provider;
+    private String providerId;
+    private String profileNickname;
+    private String profileImage;
+    private String profileThumbnailImage;
+}

--- a/src/main/java/team_alcoholic/jumo_server/user/repository/UserRepository.java
+++ b/src/main/java/team_alcoholic/jumo_server/user/repository/UserRepository.java
@@ -1,0 +1,19 @@
+package team_alcoholic.jumo_server.user.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import team_alcoholic.jumo_server.user.domain.User;
+
+import java.util.Optional;
+
+/**
+ * 사용자 Repository
+ */
+public interface UserRepository extends JpaRepository<User, String> {
+    /**
+     * provider, providerId로 사용자 조회
+     * @param provider
+     * @param providerId
+     * @return 사용자 정보
+     */
+    User findByProviderAndProviderId(String provider, String providerId);
+}

--- a/src/main/java/team_alcoholic/jumo_server/user/service/UserService.java
+++ b/src/main/java/team_alcoholic/jumo_server/user/service/UserService.java
@@ -1,0 +1,59 @@
+package team_alcoholic.jumo_server.user.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import team_alcoholic.jumo_server.auth.dto.OAuth2Response;
+import team_alcoholic.jumo_server.user.domain.User;
+import team_alcoholic.jumo_server.user.dto.UserDTO;
+import team_alcoholic.jumo_server.user.repository.UserRepository;
+
+import java.util.Optional;
+
+/**
+ * 사용자 정보를 다루는 서비스
+ */
+@Service
+@RequiredArgsConstructor
+public class UserService {
+
+    private final UserRepository userRepository;
+
+
+    public UserDTO getUser(OAuth2Response oAuth2Response) {
+        User user = userRepository.findByProviderAndProviderId(oAuth2Response.getProvider(), oAuth2Response.getProviderId());
+        if (user == null) {
+            user = createUser(oAuth2Response);
+        }
+        return convertToUserDTO(user);
+    }
+
+    /**
+     * 사용자 생성
+     *
+     * @param oAuth2Response
+     * @return 생성된 사용자 정보
+     */
+    @Transactional
+    protected User createUser(OAuth2Response oAuth2Response) {
+        User user = new User();
+        user.setProvider(oAuth2Response.getProvider());
+        user.setProviderId(oAuth2Response.getProviderId());
+        user.setProfileNickname(oAuth2Response.getProfileNickname());
+        user.setProfileImage(oAuth2Response.getProfileImage());
+        user.setProfileThumbnailImage(oAuth2Response.getProfileThumbnailImage());
+        return userRepository.save(user);
+
+    }
+
+    private UserDTO convertToUserDTO(User user) {
+        return UserDTO.builder()
+                .provider(user.getProvider())
+                .providerId(user.getProviderId())
+                .profileNickname(user.getProfileNickname())
+                .profileImage(user.getProfileImage())
+                .profileThumbnailImage(user.getProfileThumbnailImage())
+                .build();
+    }
+
+}


### PR DESCRIPTION
## 🚀 완료한 기능 혹은 수정 기능
**Jira 티켓: [BYOB-48]**


<br>

## 🔨 작업 사항 
- 유저 신규 등록 및 조회를 user 도메인에서 처리하도록 관심사 분리
- auth 도메인에서는 Oauth를 통한 인증 및 세션 등록만 하도록 함
### 기본적인 플로우
- OAuth2UserService에서 oauth2 리소스 서버에서 유저 정보 가져오기
- 이를 기반으로 UserService에서 사용자 생성(신규 가입자일 경우) 및 유저 정보 가져와서 OAuth2UserService에 UserDTO 넘겨주기
- UserService에서 받은 UserDTO를 통해 세션에 등록

## 문제 및 해결
### 구조 문제
- 어떤식으로 구조를 짜야할지 고민했다.
### 구조 해결
-  auth 도메인에서는 Oauth를 통한 인증 및 세션 등록만 하도록 히고 user 생성, 조회와 같은 관리는 user에서 처리하도록 함

[BYOB-48]: https://swm-alcoholic.atlassian.net/browse/BYOB-48?atlOrigin=eyJpIjoiMGRmNGExNDk4ZDhlNDViNGI5ZWUwNmJjNjQ0MTYxNzIiLCJwIjoiaiJ9

