### PR TITLE
[BYOB-90] 모임상세조회 요청 시 지역이 지역코드로 응답되는 문제 해결

### DIFF
--- a/src/main/java/team_alcoholic/jumo_server/meeting/service/MeetingService.java
+++ b/src/main/java/team_alcoholic/jumo_server/meeting/service/MeetingService.java
@@ -6,6 +6,8 @@ import team_alcoholic.jumo_server.meeting.domain.Meeting;
 import team_alcoholic.jumo_server.meeting.dto.MeetingDto;
 import team_alcoholic.jumo_server.meeting.dto.MeetingListDto;
 import team_alcoholic.jumo_server.meeting.repository.MeetingRepository;
+import team_alcoholic.jumo_server.region.domain.Region;
+import team_alcoholic.jumo_server.region.repository.RegionRepository;
 
 import java.util.List;
 
@@ -13,12 +15,22 @@ import java.util.List;
 public class MeetingService {
 
     private final MeetingRepository meetingRepository;
+    private final RegionRepository regionRepository;
 
     @Autowired
-    public MeetingService(MeetingRepository meetingRepository) { this.meetingRepository = meetingRepository;}
+    public MeetingService(
+        MeetingRepository meetingRepository,
+        RegionRepository regionRepository
+    ) {
+        this.meetingRepository = meetingRepository;
+        this.regionRepository = regionRepository;
+    }
 
     public MeetingDto findMeetingById(Long id) {
-        return meetingRepository.findMeetingById(id);
+        MeetingDto meeting = meetingRepository.findMeetingById(id);
+        Region region = regionRepository.findByAdmcd(meeting.getRegion());
+        meeting.setRegion(region.getAdmnm());
+        return meeting;
     }
 
     public List<MeetingListDto> findLatestMeetingList() {


### PR DESCRIPTION
## 🚀 완료한 기능 혹은 수정 기능
**Jira 티켓: [BYOB-90]**

<br>

## 🔨 작업 사항 
모임상세조회 API 요청 시, region 필드에 지역명 대신 지역코드를 담아 응답하는 문제 해결



[BYOB-90]: https://swm-alcoholic.atlassian.net/browse/BYOB-90?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ