### PR TITLE
[BYOB-98] 모임 관련 API 수정

### DIFF
--- a/src/main/java/team_alcoholic/jumo_server/meeting/controller/MeetingController.java
+++ b/src/main/java/team_alcoholic/jumo_server/meeting/controller/MeetingController.java
@@ -5,6 +5,7 @@ import org.springframework.web.bind.annotation.*;
 import team_alcoholic.jumo_server.meeting.domain.Meeting;
 import team_alcoholic.jumo_server.meeting.dto.MeetingDto;
 import team_alcoholic.jumo_server.meeting.dto.MeetingListDto;
+import team_alcoholic.jumo_server.meeting.dto.MeetingListResponseDto;
 import team_alcoholic.jumo_server.meeting.service.MeetingService;
 
 import java.util.List;
@@ -24,7 +25,7 @@ public class MeetingController {
     }
 
     @GetMapping()
-    public List<MeetingListDto> getLatestMeetingList(
+    public MeetingListResponseDto getLatestMeetingList(
         @RequestParam(required = false, defaultValue = "latest") String sort,
         @RequestParam(required = false, defaultValue = "30") int limit,
         @RequestParam(required = false, defaultValue = "0") Long cursor

--- a/src/main/java/team_alcoholic/jumo_server/meeting/controller/MeetingController.java
+++ b/src/main/java/team_alcoholic/jumo_server/meeting/controller/MeetingController.java
@@ -1,10 +1,7 @@
 package team_alcoholic.jumo_server.meeting.controller;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import team_alcoholic.jumo_server.meeting.domain.Meeting;
 import team_alcoholic.jumo_server.meeting.dto.MeetingDto;
 import team_alcoholic.jumo_server.meeting.dto.MeetingListDto;
@@ -13,7 +10,7 @@ import team_alcoholic.jumo_server.meeting.service.MeetingService;
 import java.util.List;
 
 @RestController
-@RequestMapping("meeting")
+@RequestMapping("meetings")
 public class MeetingController {
 
     private final MeetingService meetingService;
@@ -26,13 +23,15 @@ public class MeetingController {
         return meetingService.findMeetingById(id);
     }
 
-    @GetMapping("list/latest")
-    public List<MeetingListDto> getLatestMeetingList() {
-        return meetingService.findLatestMeetingList();
-    }
-
-    @GetMapping("list/latest/{id}")
-    public List<MeetingListDto> getLatestMeetingListById(@PathVariable Long id) {
-        return meetingService.findLatestMeetingListById(id);
+    @GetMapping()
+    public List<MeetingListDto> getLatestMeetingList(
+        @RequestParam(required = false, defaultValue = "latest") String sort,
+        @RequestParam(required = false, defaultValue = "30") int limit,
+        @RequestParam(required = false, defaultValue = "0") Long cursor
+    ) {
+        switch (sort) {
+            default:
+                return meetingService.findLatestMeetingList(limit, cursor);
+        }
     }
 }

--- a/src/main/java/team_alcoholic/jumo_server/meeting/dto/MeetingListResponseDto.java
+++ b/src/main/java/team_alcoholic/jumo_server/meeting/dto/MeetingListResponseDto.java
@@ -1,0 +1,16 @@
+package team_alcoholic.jumo_server.meeting.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+@AllArgsConstructor
+public class MeetingListResponseDto {
+    private List<MeetingListDto> meetings;
+    private Long lastId;
+    private boolean eof;
+}

--- a/src/main/java/team_alcoholic/jumo_server/meeting/repository/JpaMeetingRepository.java
+++ b/src/main/java/team_alcoholic/jumo_server/meeting/repository/JpaMeetingRepository.java
@@ -29,15 +29,17 @@ public class JpaMeetingRepository implements MeetingRepository{
     }
 
     @Override
-    public List<MeetingListDto> findLatestMeetingList() {
-        return em.createQuery("select new team_alcoholic.jumo_server.meeting.dto.MeetingListDto(m.id, m.uuid, m.name, m.status, m.meetingAt, m.fixAt, r.admnm, m.liquors, m.participatesMin, m.participatesMax, m.payment, m.byob, m.thumbnailImage, m.externalService) from Meeting m, Region r where m.region=r.admcd order by m.id desc limit 30", MeetingListDto.class)
+    public List<MeetingListDto> findLatestMeetingList(int limit) {
+        return em.createQuery("select new team_alcoholic.jumo_server.meeting.dto.MeetingListDto(m.id, m.uuid, m.name, m.status, m.meetingAt, m.fixAt, r.admnm, m.liquors, m.participatesMin, m.participatesMax, m.payment, m.byob, m.thumbnailImage, m.externalService) from Meeting m, Region r where m.region=r.admcd order by m.id desc limit :limit", MeetingListDto.class)
+            .setParameter("limit", limit)
             .getResultList();
     }
 
     @Override
-    public List<MeetingListDto> findLatestMeetingListById(Long id) {
-        return em.createQuery("select new team_alcoholic.jumo_server.meeting.dto.MeetingListDto(m.id, m.uuid, m.name, m.status, m.meetingAt, m.fixAt, r.admnm, m.liquors, m.participatesMin, m.participatesMax, m.payment, m.byob, m.thumbnailImage, m.externalService) from Meeting m, Region r where m.region=r.admcd and m.id<:id order by m.id desc limit 30", MeetingListDto.class)
-            .setParameter("id", id)
+    public List<MeetingListDto> findLatestMeetingListById(int limit, Long cursor) {
+        return em.createQuery("select new team_alcoholic.jumo_server.meeting.dto.MeetingListDto(m.id, m.uuid, m.name, m.status, m.meetingAt, m.fixAt, r.admnm, m.liquors, m.participatesMin, m.participatesMax, m.payment, m.byob, m.thumbnailImage, m.externalService) from Meeting m, Region r where m.region=r.admcd and m.id<:cursor order by m.id desc limit :limit", MeetingListDto.class)
+            .setParameter("limit", limit)
+            .setParameter("cursor", cursor)
             .getResultList();
     }
 }

--- a/src/main/java/team_alcoholic/jumo_server/meeting/repository/MeetingRepository.java
+++ b/src/main/java/team_alcoholic/jumo_server/meeting/repository/MeetingRepository.java
@@ -8,6 +8,6 @@ import java.util.List;
 
 public interface MeetingRepository {
     MeetingDto findMeetingById(Long id);
-    List<MeetingListDto> findLatestMeetingList();
-    List<MeetingListDto> findLatestMeetingListById(Long id);
+    List<MeetingListDto> findLatestMeetingList(int limit);
+    List<MeetingListDto> findLatestMeetingListById(int limit, Long cursor);
 }

--- a/src/main/java/team_alcoholic/jumo_server/meeting/service/MeetingService.java
+++ b/src/main/java/team_alcoholic/jumo_server/meeting/service/MeetingService.java
@@ -38,6 +38,8 @@ public class MeetingService {
         List<MeetingListDto> meetings;
         if (cursor==0) meetings = meetingRepository.findLatestMeetingList(limit+1);
         else meetings = meetingRepository.findLatestMeetingListById(limit+1, cursor);
-        return new MeetingListResponseDto(meetings, meetings.get(meetings.size()-1).getId(), (meetings.size()<limit+1));
+        boolean eof = (meetings.size()<limit+1);
+        if (!eof) meetings.remove(meetings.size()-1);
+        return new MeetingListResponseDto(meetings, meetings.get(meetings.size()-1).getId(), eof);
     }
 }

--- a/src/main/java/team_alcoholic/jumo_server/meeting/service/MeetingService.java
+++ b/src/main/java/team_alcoholic/jumo_server/meeting/service/MeetingService.java
@@ -33,11 +33,8 @@ public class MeetingService {
         return meeting;
     }
 
-    public List<MeetingListDto> findLatestMeetingList() {
-        return meetingRepository.findLatestMeetingList();
-    }
-
-    public List<MeetingListDto> findLatestMeetingListById(Long id) {
-        return meetingRepository.findLatestMeetingListById(id);
+    public List<MeetingListDto> findLatestMeetingList(int limit, Long cursor) {
+        if (cursor==0) return meetingRepository.findLatestMeetingList(limit);
+        return meetingRepository.findLatestMeetingListById(limit, cursor);
     }
 }

--- a/src/main/java/team_alcoholic/jumo_server/meeting/service/MeetingService.java
+++ b/src/main/java/team_alcoholic/jumo_server/meeting/service/MeetingService.java
@@ -5,6 +5,7 @@ import org.springframework.stereotype.Service;
 import team_alcoholic.jumo_server.meeting.domain.Meeting;
 import team_alcoholic.jumo_server.meeting.dto.MeetingDto;
 import team_alcoholic.jumo_server.meeting.dto.MeetingListDto;
+import team_alcoholic.jumo_server.meeting.dto.MeetingListResponseDto;
 import team_alcoholic.jumo_server.meeting.repository.MeetingRepository;
 import team_alcoholic.jumo_server.region.domain.Region;
 import team_alcoholic.jumo_server.region.repository.RegionRepository;
@@ -33,8 +34,10 @@ public class MeetingService {
         return meeting;
     }
 
-    public List<MeetingListDto> findLatestMeetingList(int limit, Long cursor) {
-        if (cursor==0) return meetingRepository.findLatestMeetingList(limit);
-        return meetingRepository.findLatestMeetingListById(limit, cursor);
+    public MeetingListResponseDto findLatestMeetingList(int limit, Long cursor) {
+        List<MeetingListDto> meetings;
+        if (cursor==0) meetings = meetingRepository.findLatestMeetingList(limit+1);
+        else meetings = meetingRepository.findLatestMeetingListById(limit+1, cursor);
+        return new MeetingListResponseDto(meetings, meetings.get(meetings.size()-1).getId(), (meetings.size()<limit+1));
     }
 }


### PR DESCRIPTION
## 🚀 완료한 기능 혹은 수정 기능
**Jira 티켓: [BYOB-98]**

<br>

## 🔨 작업 사항 
**모임 상세 조회**
meeting -> meetings로 변경

**모임 목록 조회**
- RESTful url로 변경: meeting -> meetings, queryString 사용
- 응답 형식 배열에서 객체로 수정
- 커서 페이지네이션 수행할 때 eof 여부 판단하는 로직 추가


[BYOB-98]: https://swm-alcoholic.atlassian.net/browse/BYOB-98?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ