### PR TITLE
[BYOB-131] log 시간대를 한국 시간대에 맞게 수정

### DIFF
--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <configuration timeZone="Asia/Seoul">
-    <!-- 기본 콘솔 출력 설정 -->
+
+    <!-- 로컬 환경 콘솔 출력 설정 -->
     <springProfile name="default,local">
         <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
         <include resource="org/springframework/boot/logging/logback/console-appender.xml"/>
@@ -19,7 +20,7 @@
 
         <appender name="aws_cloudwatch_log" class="ca.pjer.logback.AwsLogsAppender">
             <layout>
-                <pattern>[%thread] [%date{yyyy-MM-dd HH:mm:ss}] [%level] [%file:%line] - %msg%n</pattern>
+                <pattern>[%thread] [%date{yyyy-MM-dd HH:mm:ss,Asia/Seoul}] [%level] [%file:%line] - %msg%n</pattern>
             </layout>
             <logGroupName>${name}</logGroupName>
             <logStreamUuidPrefix>jumo-server-dev/</logStreamUuidPrefix>


### PR DESCRIPTION
## 🚀 완료한 기능 혹은 수정 기능
**Jira 티켓: [BYOB-131]**

<br>

## 🔨 작업 사항 
log 시간대를 한국 시간대에 맞게 수정.
AWS CloudWatch에서 확인해보니 로그 시간대가 UTC로 찍히고 있어서 수정했읍니다



[BYOB-131]: https://swm-alcoholic.atlassian.net/browse/BYOB-131?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ