### PR TITLE
[BYOB-157] 모임 목록 API가 호출될 때, liquors가 지정되지 않은 경우 처리에 대한 버그 수정

### DIFF
--- a/src/main/java/team_alcoholic/jumo_server/domain/meeting/controller/MeetingController.java
+++ b/src/main/java/team_alcoholic/jumo_server/domain/meeting/controller/MeetingController.java
@@ -29,7 +29,7 @@ public class MeetingController implements MeetingApi {
             @RequestParam(name = "cursor-id", required = false, defaultValue = "0") Long cursorId,
             @RequestParam(name = "cursor-date", required = false)
             @DateTimeFormat(pattern = "yyyy-MM-dd HH:mm:ss") LocalDateTime cursorDate,
-            @RequestParam(name = "liquors", required = false, defaultValue = "whiskey,wine") String[] liquors) {
+            @RequestParam(name = "liquors", required = false, defaultValue = "whisky,wine") String[] liquors) {
 
         return meetingService.findLatestMeetingList(limit, cursorId, sort, cursorDate, List.of(liquors));
     }

--- a/src/main/java/team_alcoholic/jumo_server/domain/meeting/service/MeetingService.java
+++ b/src/main/java/team_alcoholic/jumo_server/domain/meeting/service/MeetingService.java
@@ -69,6 +69,7 @@ public class MeetingService {
 
         eof = (meetings.size() < limit + 1);
 
+        System.out.println(convertedLiquors);
         System.out.println("미팅 크기와 eof() : " + meetings.size() + eof);
         // liquors에 들어있는 항목
         System.out.println("liquors : " + liquors);

--- a/src/main/java/team_alcoholic/jumo_server/domain/meeting/service/MeetingService.java
+++ b/src/main/java/team_alcoholic/jumo_server/domain/meeting/service/MeetingService.java
@@ -69,7 +69,6 @@ public class MeetingService {
 
         eof = (meetings.size() < limit + 1);
 
-        System.out.println(convertedLiquors);
         System.out.println("미팅 크기와 eof() : " + meetings.size() + eof);
         // liquors에 들어있는 항목
         System.out.println("liquors : " + liquors);


### PR DESCRIPTION
## 🚀 완료한 기능 혹은 수정 기능
**Jira 티켓: [BYOB-157]**

<br>

## 🔨 작업 사항 
- 문제: 모임 목록 API가 호출될 때 liquors가 지정되지 않은 경우에, default value가 "whisky,wine"으로 설정되어야 하는데 와인에 대한 필터만 적용되는 문제 발생
- 해결: MeetingController에 defaultValue가 오타 발생한 채로 지정되어 있었음



[BYOB-157]: https://swm-alcoholic.atlassian.net/browse/BYOB-157?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ