### PR TITLE
[BYOB-174] gpt 주류 노트 api 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -65,7 +65,7 @@ dependencies {
 
     // spring ai
     implementation platform("org.springframework.ai:spring-ai-bom:1.0.0-SNAPSHOT")
-    implementation 'org.springframework.ai:spring-ai-openai'
+//    implementation 'org.springframework.ai:spring-ai-openai'
     implementation 'org.springframework.ai:spring-ai-openai-spring-boot-starter'
 
 

--- a/build.gradle
+++ b/build.gradle
@@ -21,6 +21,8 @@ configurations {
 
 repositories {
     mavenCentral()
+    maven { url 'https://repo.spring.io/milestone' }
+    maven { url 'https://repo.spring.io/snapshot' }
 }
 
 dependencies {
@@ -60,6 +62,12 @@ dependencies {
     //jackson
     implementation 'com.fasterxml.jackson.core:jackson-databind'
     implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
+
+    // spring ai
+    implementation platform("org.springframework.ai:spring-ai-bom:1.0.0-SNAPSHOT")
+    implementation 'org.springframework.ai:spring-ai-openai'
+    implementation 'org.springframework.ai:spring-ai-openai-spring-boot-starter'
+
 
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/src/main/java/team_alcoholic/jumo_server/domain/liquor/domain/Liquor.java
+++ b/src/main/java/team_alcoholic/jumo_server/domain/liquor/domain/Liquor.java
@@ -2,6 +2,7 @@ package team_alcoholic.jumo_server.domain.liquor.domain;
 
 import jakarta.persistence.*;
 import lombok.Getter;
+import team_alcoholic.jumo_server.domain.tastingnote.domain.AiTastingNote;
 import team_alcoholic.jumo_server.domain.tastingnote.domain.TastingNote;
 import team_alcoholic.jumo_server.global.common.domain.BaseEntity;
 
@@ -30,6 +31,10 @@ public class Liquor extends BaseEntity {
     private String country;
     private String region;
     private String grapeVariety;
+
+    @OneToOne(mappedBy = "liquor", fetch = FetchType.LAZY, cascade = CascadeType.ALL, optional = true)
+    private AiTastingNote aiTastingNote;
+
 
     @OneToMany(mappedBy = "liquor", fetch = FetchType.LAZY)
     private List<TastingNote> tastingNotes;

--- a/src/main/java/team_alcoholic/jumo_server/domain/liquor/dto/LiquorResDto.java
+++ b/src/main/java/team_alcoholic/jumo_server/domain/liquor/dto/LiquorResDto.java
@@ -2,6 +2,7 @@ package team_alcoholic.jumo_server.domain.liquor.dto;
 
 import lombok.Builder;
 import team_alcoholic.jumo_server.domain.liquor.domain.Liquor;
+import team_alcoholic.jumo_server.domain.tastingnote.dto.AiNotesResDTO;
 
 public record LiquorResDto(
         String thumbnailImageUrl,
@@ -16,6 +17,7 @@ public record LiquorResDto(
         String tastingNotesAroma,
         String tastingNotesTaste,
         String tastingNotesFinish,
+        AiNotesResDTO aiNotes,
         String createdAt,
         String updatedAt,
         String createdBy,
@@ -39,6 +41,7 @@ public record LiquorResDto(
                 .tastingNotesAroma(liquor.getTastingNotesAroma())
                 .tastingNotesTaste(liquor.getTastingNotesTaste())
                 .tastingNotesFinish(liquor.getTastingNotesFinish())
+                .aiNotes(AiNotesResDTO.fromEntity(liquor.getAiTastingNote()))
                 .createdAt(liquor.getCreatedAt().toString())
                 .updatedAt(liquor.getUpdatedAt().toString())
                 .createdBy("dailyshot".equals(liquor.getCreatedBy()) ? "jumo" : liquor.getCreatedBy())

--- a/src/main/java/team_alcoholic/jumo_server/domain/tastingnote/controller/TastingNoteController.java
+++ b/src/main/java/team_alcoholic/jumo_server/domain/tastingnote/controller/TastingNoteController.java
@@ -1,20 +1,14 @@
 package team_alcoholic.jumo_server.domain.tastingnote.controller;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.ai.chat.client.ChatClient;
-import org.springframework.ai.openai.OpenAiChatModel;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.web.bind.annotation.*;
-import team_alcoholic.jumo_server.domain.tastingnote.dto.TastingNoteListResDTO;
-import team_alcoholic.jumo_server.domain.tastingnote.dto.TastingNoteReqDTO;
-import team_alcoholic.jumo_server.domain.tastingnote.dto.TastingNoteResDTO;
-import team_alcoholic.jumo_server.domain.tastingnote.dto.TastingNoteSimilarResDto;
+import team_alcoholic.jumo_server.domain.tastingnote.dto.*;
 import team_alcoholic.jumo_server.domain.tastingnote.service.TastingNoteService;
 import team_alcoholic.jumo_server.domain.user.domain.User;
 import team_alcoholic.jumo_server.domain.user.service.UserService;
@@ -29,7 +23,6 @@ public class TastingNoteController {
 
     private final TastingNoteService tastingNoteService;
     private final UserService userService;
-    private final ChatClient chatClient;
 
 
     @GetMapping("/similar-tasting-notes")
@@ -41,24 +34,11 @@ public class TastingNoteController {
         return tastingNoteService.findSimilarTastingNotes(keyword, exclude, limit);
     }
 
-    @GetMapping("/ai/generate")
-    public Map generate(@RequestParam(value = "message", defaultValue = "카발란 솔리스트 비노바리끄의 테이스팅 노트를 알려줘\n") String message) {
-        String generation = chatClient.prompt()
-                .user(message)
-                .call()
-                .content();
 
-        try {
-            // JSON 문자열을 파싱하기 위해 ObjectMapper 사용
-            ObjectMapper objectMapper = new ObjectMapper();
-            // generation 값을 JSON으로 파싱
+    @GetMapping("/ai-similar-tasting-notes/{liquorId}")
+    public GenerateTastingNotesResDTO generateTastingNotes(@PathVariable Long liquorId) {
+        return tastingNoteService.generateTastingNotes(liquorId);
 
-            // noseNotes, palateNotes, finishNotes만 포함된 맵을 반환
-            return objectMapper.readValue(generation, Map.class);
-        } catch (Exception e) {
-            // 에러 발생 시 기본 메시지 반환
-            return Map.of("error", "Failed to parse JSON");
-        }
     }
 
 

--- a/src/main/java/team_alcoholic/jumo_server/domain/tastingnote/controller/TastingNoteController.java
+++ b/src/main/java/team_alcoholic/jumo_server/domain/tastingnote/controller/TastingNoteController.java
@@ -1,14 +1,13 @@
 package team_alcoholic.jumo_server.domain.tastingnote.controller;
 
-import com.amazonaws.services.secretsmanager.model.ResourceNotFoundException;
-import jakarta.servlet.http.Cookie;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.ai.openai.OpenAiChatModel;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.web.bind.annotation.*;
@@ -30,6 +29,7 @@ public class TastingNoteController {
 
     private final TastingNoteService tastingNoteService;
     private final UserService userService;
+    private final ChatClient chatClient;
 
 
     @GetMapping("/similar-tasting-notes")
@@ -41,12 +41,30 @@ public class TastingNoteController {
         return tastingNoteService.findSimilarTastingNotes(keyword, exclude, limit);
     }
 
+    @GetMapping("/ai/generate")
+    public Map generate(@RequestParam(value = "message", defaultValue = "카발란 솔리스트 비노바리끄의 테이스팅 노트를 알려줘\n") String message) {
+        String generation = chatClient.prompt()
+                .user(message)
+                .call()
+                .content();
+
+        try {
+            // JSON 문자열을 파싱하기 위해 ObjectMapper 사용
+            ObjectMapper objectMapper = new ObjectMapper();
+            // generation 값을 JSON으로 파싱
+
+            // noseNotes, palateNotes, finishNotes만 포함된 맵을 반환
+            return objectMapper.readValue(generation, Map.class);
+        } catch (Exception e) {
+            // 에러 발생 시 기본 메시지 반환
+            return Map.of("error", "Failed to parse JSON");
+        }
+    }
+
 
     @PostMapping("/tasting-notes")
     public ResponseEntity<Long> saveTastingNote(@RequestBody @Valid TastingNoteReqDTO tastingNoteReqDTO,
                                                 @AuthenticationPrincipal OAuth2User oAuth2User) {
-
-
 
 
         // 임시로 처리

--- a/src/main/java/team_alcoholic/jumo_server/domain/tastingnote/domain/AiTastingNote.java
+++ b/src/main/java/team_alcoholic/jumo_server/domain/tastingnote/domain/AiTastingNote.java
@@ -1,0 +1,31 @@
+package team_alcoholic.jumo_server.domain.tastingnote.domain;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import team_alcoholic.jumo_server.domain.liquor.domain.Liquor;
+import team_alcoholic.jumo_server.global.common.domain.BaseEntity;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class AiTastingNote extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "liquor_id")
+    private Liquor liquor;
+
+    private String tastingNotesAroma;
+
+    private String tastingNotesFinish;
+
+    private String tastingNotesTaste;
+}

--- a/src/main/java/team_alcoholic/jumo_server/domain/tastingnote/dto/AiNotesResDTO.java
+++ b/src/main/java/team_alcoholic/jumo_server/domain/tastingnote/dto/AiNotesResDTO.java
@@ -1,0 +1,25 @@
+package team_alcoholic.jumo_server.domain.tastingnote.dto;
+
+import lombok.Builder;
+import team_alcoholic.jumo_server.domain.tastingnote.domain.AiTastingNote;
+
+public record AiNotesResDTO(
+        String tastingNotesAroma,
+        String tastingNotesTaste,
+        String tastingNotesFinish) {
+
+    @Builder
+    public AiNotesResDTO {
+    }
+
+    public static AiNotesResDTO fromEntity(AiTastingNote aiTastingNote) {
+        if (aiTastingNote == null) {
+            return null;
+        }
+        return AiNotesResDTO.builder()
+                .tastingNotesAroma(aiTastingNote.getTastingNotesAroma())
+                .tastingNotesTaste(aiTastingNote.getTastingNotesTaste())
+                .tastingNotesFinish(aiTastingNote.getTastingNotesFinish())
+                .build();
+    }
+}

--- a/src/main/java/team_alcoholic/jumo_server/domain/tastingnote/dto/GenerateTastingNotesResDTO.java
+++ b/src/main/java/team_alcoholic/jumo_server/domain/tastingnote/dto/GenerateTastingNotesResDTO.java
@@ -1,0 +1,14 @@
+package team_alcoholic.jumo_server.domain.tastingnote.dto;
+
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class GenerateTastingNotesResDTO {
+
+    private List<String> noseNotes;
+    private List<String> palateNotes;
+    private List<String> finishNotes;
+
+}

--- a/src/main/java/team_alcoholic/jumo_server/domain/tastingnote/repository/AiTastingNoteRepository.java
+++ b/src/main/java/team_alcoholic/jumo_server/domain/tastingnote/repository/AiTastingNoteRepository.java
@@ -1,0 +1,7 @@
+package team_alcoholic.jumo_server.domain.tastingnote.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import team_alcoholic.jumo_server.domain.tastingnote.domain.AiTastingNote;
+
+public interface AiTastingNoteRepository extends JpaRepository<AiTastingNote, Long> {
+}

--- a/src/main/java/team_alcoholic/jumo_server/domain/tastingnote/service/TastingNoteService.java
+++ b/src/main/java/team_alcoholic/jumo_server/domain/tastingnote/service/TastingNoteService.java
@@ -8,8 +8,10 @@ import org.springframework.stereotype.Service;
 import team_alcoholic.jumo_server.domain.liquor.domain.Liquor;
 import team_alcoholic.jumo_server.domain.liquor.exception.LiquorNotFoundException;
 import team_alcoholic.jumo_server.domain.liquor.repository.LiquorRepository;
+import team_alcoholic.jumo_server.domain.tastingnote.domain.AiTastingNote;
 import team_alcoholic.jumo_server.domain.tastingnote.domain.TastingNote;
 import team_alcoholic.jumo_server.domain.tastingnote.dto.*;
+import team_alcoholic.jumo_server.domain.tastingnote.repository.AiTastingNoteRepository;
 import team_alcoholic.jumo_server.domain.tastingnote.repository.TastingNoteRepository;
 import team_alcoholic.jumo_server.domain.tastingnote.repository.TastingNoteSimilarityVectorsRepository;
 import team_alcoholic.jumo_server.domain.user.domain.User;
@@ -25,6 +27,7 @@ public class TastingNoteService {
     private final TastingNoteSimilarityVectorsRepository tastingNoteSimilarityVectorsRepository;
     private final TastingNoteRepository tastingNoteRepository;
     private final LiquorRepository liquorRepository;
+    private final AiTastingNoteRepository aiTastingNoteRepository;
     private final ChatClient chatClient;
     private final ObjectMapper objectMapper;
 
@@ -45,7 +48,7 @@ public class TastingNoteService {
     public Long saveTastingNote(TastingNoteReqDTO tastingNoteReqDTO, User user) {
 
         Liquor liquor = liquorRepository.findById(tastingNoteReqDTO.getLiquorId())
-                .orElseThrow(() -> new IllegalArgumentException("비상 liquor ID"));
+                .orElseThrow(() -> new LiquorNotFoundException(tastingNoteReqDTO.getLiquorId()));
         TastingNote newTastingNote = convertToEntity(tastingNoteReqDTO, liquor, user);
 
         return tastingNoteRepository.save(newTastingNote).getId();
@@ -89,8 +92,12 @@ public class TastingNoteService {
                 .orElseThrow(() -> new LiquorNotFoundException(liquorId));
         String liquorInfo = liquorToStringConverter(liquor);
         String generation = generateFromChatClient(liquorInfo);
+        GenerateTastingNotesResDTO tastingNotesResDTO = parseGenerationResult(generation);
 
-        return parseGenerationResult(generation);
+        // AI 테이스팅 노트를 저장
+        saveAiTastingNote(tastingNotesResDTO, liquor);
+
+        return tastingNotesResDTO;
     }
 
     private String generateFromChatClient(String liquorInfo) {
@@ -105,7 +112,23 @@ public class TastingNoteService {
             // JSON 문자열을 DTO 객체로 변환
             return objectMapper.readValue(generation, GenerateTastingNotesResDTO.class);
         } catch (Exception e) {
-           throw new IllegalArgumentException("테이스팅 노트 생성에 실패했습니다.");
+            throw new IllegalArgumentException("테이스팅 노트 생성에 실패했습니다.");
+        }
+    }
+
+    // 저장 실패해도 ai결과값은 응답함
+    private void saveAiTastingNote(GenerateTastingNotesResDTO tastingNotesResDTO, Liquor liquor) {
+        try {
+            AiTastingNote aiTastingNote = AiTastingNote.builder()
+                    .liquor(liquor)
+                    .tastingNotesAroma(String.join(", ", tastingNotesResDTO.getNoseNotes()))
+                    .tastingNotesTaste(String.join(", ", tastingNotesResDTO.getPalateNotes()))
+                    .tastingNotesFinish(String.join(", ", tastingNotesResDTO.getFinishNotes()))
+                    .build();
+
+            aiTastingNoteRepository.save(aiTastingNote);
+        } catch (Exception e) {
+            System.err.println("Failed to save AI tasting note to the database: " + e.getMessage());
         }
     }
 

--- a/src/main/java/team_alcoholic/jumo_server/domain/tastingnote/service/TastingNoteService.java
+++ b/src/main/java/team_alcoholic/jumo_server/domain/tastingnote/service/TastingNoteService.java
@@ -1,20 +1,21 @@
 package team_alcoholic.jumo_server.domain.tastingnote.service;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
+import org.springframework.ai.chat.client.ChatClient;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import team_alcoholic.jumo_server.domain.liquor.domain.Liquor;
+import team_alcoholic.jumo_server.domain.liquor.exception.LiquorNotFoundException;
 import team_alcoholic.jumo_server.domain.liquor.repository.LiquorRepository;
 import team_alcoholic.jumo_server.domain.tastingnote.domain.TastingNote;
-import team_alcoholic.jumo_server.domain.tastingnote.dto.TastingNoteListResDTO;
-import team_alcoholic.jumo_server.domain.tastingnote.dto.TastingNoteReqDTO;
-import team_alcoholic.jumo_server.domain.tastingnote.dto.TastingNoteResDTO;
-import team_alcoholic.jumo_server.domain.tastingnote.dto.TastingNoteSimilarResDto;
+import team_alcoholic.jumo_server.domain.tastingnote.dto.*;
 import team_alcoholic.jumo_server.domain.tastingnote.repository.TastingNoteRepository;
 import team_alcoholic.jumo_server.domain.tastingnote.repository.TastingNoteSimilarityVectorsRepository;
 import team_alcoholic.jumo_server.domain.user.domain.User;
 
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 @Service
@@ -24,6 +25,9 @@ public class TastingNoteService {
     private final TastingNoteSimilarityVectorsRepository tastingNoteSimilarityVectorsRepository;
     private final TastingNoteRepository tastingNoteRepository;
     private final LiquorRepository liquorRepository;
+    private final ChatClient chatClient;
+    private final ObjectMapper objectMapper;
+
 
     /**
      * 주어진 테이스팅 노트와 기존 리스트를 제외하고 상위 유사도 높은 테이스팅 노트들을 반환
@@ -67,14 +71,77 @@ public class TastingNoteService {
 
     public TastingNoteResDTO getTastingNoteById(Long id) {
         TastingNote tastingNote = tastingNoteRepository.findById(id)
-                .orElseThrow(() -> new IllegalArgumentException("Invalid tasting note ID"));
+                .orElseThrow(() -> new LiquorNotFoundException(id));
 
         return TastingNoteResDTO.fromEntity(tastingNote);
     }
 
-    /** Liquor id에 해당하는 테이스팅 노트 목록을 반환 */
+    /**
+     * Liquor id에 해당하는 테이스팅 노트 목록을 반환
+     */
     public List<TastingNoteListResDTO> getTastingNoteListByLiquor(Long liquor) {
         List<TastingNote> result = tastingNoteRepository.findTastingNotesByLiquorId(liquor);
         return result.stream().map(TastingNoteListResDTO::fromEntity).collect(Collectors.toList());
+    }
+
+    public GenerateTastingNotesResDTO generateTastingNotes(Long liquorId) {
+        Liquor liquor = liquorRepository.findById(liquorId)
+                .orElseThrow(() -> new LiquorNotFoundException(liquorId));
+        String liquorInfo = liquorToStringConverter(liquor);
+        String generation = generateFromChatClient(liquorInfo);
+
+        return parseGenerationResult(generation);
+    }
+
+    private String generateFromChatClient(String liquorInfo) {
+        return chatClient.prompt()
+                .user(liquorInfo)
+                .call()
+                .content();
+    }
+
+    private GenerateTastingNotesResDTO parseGenerationResult(String generation) {
+        try {
+            // JSON 문자열을 DTO 객체로 변환
+            return objectMapper.readValue(generation, GenerateTastingNotesResDTO.class);
+        } catch (Exception e) {
+           throw new IllegalArgumentException("테이스팅 노트 생성에 실패했습니다.");
+        }
+    }
+
+    private String liquorToStringConverter(Liquor liquor) {
+        StringBuilder liquorInfo = new StringBuilder("Liquor Information: ");
+
+        if (liquor.getKoName() != null) {
+            liquorInfo.append("Name (KO) = ").append(liquor.getKoName()).append(", ");
+        }
+        if (liquor.getEnName() != null) {
+            liquorInfo.append("Name (EN) = ").append(liquor.getEnName()).append(", ");
+        }
+        if (liquor.getType() != null) {
+            liquorInfo.append("Type = ").append(liquor.getType()).append(", ");
+        }
+        if (liquor.getAbv() != null) {
+            liquorInfo.append("ABV = ").append(liquor.getAbv()).append("%, ");
+        }
+        if (liquor.getVolume() != null) {
+            liquorInfo.append("Volume = ").append(liquor.getVolume()).append(", ");
+        }
+        if (liquor.getCountry() != null) {
+            liquorInfo.append("Country = ").append(liquor.getCountry()).append(", ");
+        }
+        if (liquor.getRegion() != null) {
+            liquorInfo.append("Region = ").append(liquor.getRegion()).append(", ");
+        }
+        if (liquor.getGrapeVariety() != null) {
+            liquorInfo.append("Grape Variety = ").append(liquor.getGrapeVariety()).append(", ");
+        }
+
+        // 마지막 쉼표와 공백 제거
+        if (!liquorInfo.isEmpty()) {
+            liquorInfo.setLength(liquorInfo.length() - 2);
+        }
+
+        return liquorInfo.toString();
     }
 }

--- a/src/main/java/team_alcoholic/jumo_server/global/config/SpringAIConfig.java
+++ b/src/main/java/team_alcoholic/jumo_server/global/config/SpringAIConfig.java
@@ -1,0 +1,15 @@
+package team_alcoholic.jumo_server.global.config;
+
+import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SpringAIConfig {
+    @Bean
+    ChatClient chatClient(ChatClient.Builder builder) {
+        return builder.defaultSystem("유저가 주류에 대한 정보를 주면 이에 대한 테이스팅 노트를 한국어 단어들로 줘야해. 이때 각각의 노트들은 7개를 줘야해")
+                .build();
+    }
+
+}

--- a/src/main/resources/application-local.properties
+++ b/src/main/resources/application-local.properties
@@ -46,6 +46,17 @@ opensearch.host=${OPENSEARCH_HOST}
 opensearch.username=${OPENSEARCH_USERNAME}
 opensearch.password=${OPENSEARCH_PASSWORD}
 
+
+# openai api
+spring.ai.openai.api-key=${OPENAI_API_KEY}
+spring.ai.openai.chat.options.model=gpt-4o-2024-08-06
+spring.ai.openai.chat.options.response-format.type=JSON_SCHEMA
+spring.ai.openai.chat.options.response-format.name=MySchemaName
+spring.ai.openai.chat.options.response-format.schema={"type":"object","properties":{"noseNotes":{"type":"array","items":{"type":"string"}},"palateNotes":{"type":"array","items":{"type":"string"}},"finishNotes":{"type":"array","items":{"type":"string"}}},"required":["noseNotes","palateNotes","finishNotes"],"additionalProperties":false}
+spring.ai.openai.chat.options.response-format.strict=true
+
+
+
 # Network Debugging
 #logging.level.org.apache.http=DEBUG
 #logging.level.org.apache.http.wire=DEBUG


### PR DESCRIPTION
## 🚀 완료한 기능 혹은 수정 기능
**Jira 티켓: [BYOB-174]**

<br>

## 🔨 작업 사항 
- springAI 추가
- 주류 정보를 통해 gpt-4o로부터 테이스팅 노트 가져온 다음 디비에 저장하게 함
- 주류 정보 가져올때 ainote있으면 같이 보내게 함
- https://docs.spring.io/spring-ai/reference/api/chat/openai-chat.html
- 스프링 공식 문서 최고



[BYOB-174]: https://swm-alcoholic.atlassian.net/browse/BYOB-174?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ