### PR TITLE
[BYOB-205] OpenSearch 검색 방식 변경에 따른 관련 코드 수정

### DIFF
--- a/src/main/java/team_alcoholic/jumo_server/domain/liquorsearch/domain/LiquorES.java
+++ b/src/main/java/team_alcoholic/jumo_server/domain/liquorsearch/domain/LiquorES.java
@@ -23,6 +23,7 @@ public class LiquorES {
     private String product_id;
     private String en_name;
     private String ko_name;
+    private String ko_name_origin;
     private String price;
     private String thumbnail_image_url;
     private String tasting_notes_aroma;

--- a/src/main/java/team_alcoholic/jumo_server/domain/liquorsearch/service/LiquorSearchService.java
+++ b/src/main/java/team_alcoholic/jumo_server/domain/liquorsearch/service/LiquorSearchService.java
@@ -18,7 +18,7 @@ import java.util.List;
 public class LiquorSearchService {
 
     private final OpenSearchClient openSearchClient;
-    private static final String indexName = "test";
+    private static final String indexName = "liquors";
 
     public LiquorSearchService(OpenSearchClient openSearchClient) {
         this.openSearchClient = openSearchClient;
@@ -42,15 +42,11 @@ public class LiquorSearchService {
 //                        .fuzziness("AUTO")))
 //                .build();
 
-
-
-
         SearchRequest request = new SearchRequest.Builder()
             .index(indexName)
             .query(q -> q.multiMatch(m -> m
                 .query(keyword)
-                .fields("ko_name.nori", "en_name.english")
-                .fuzziness("AUTO")
+                .fields("ko_name.jaso", "en_name.english")
             ))
             .size(20)
             .build();

--- a/src/main/java/team_alcoholic/jumo_server/domain/liquorsearch/service/LiquorSearchService.java
+++ b/src/main/java/team_alcoholic/jumo_server/domain/liquorsearch/service/LiquorSearchService.java
@@ -26,21 +26,9 @@ public class LiquorSearchService {
 
     public List<LiquorES> search(String keyword) {
 
-        log.info("들어온 키워드"+ keyword);
+        log.info("들어온 키워드: "+ keyword);
 
         List<LiquorES> resultList = new ArrayList<>();
-
-//        SearchRequest request = new SearchRequest.Builder()
-//            .index(indexName)
-//            .query(q -> q.queryString(qs -> qs.fields("ko_name").query(keyword)))
-//            .build();
-
-//        SearchRequest request = new SearchRequest.Builder()
-//                .index(indexName)
-//                .query(q -> q.match(m -> m.field("ko_name")
-//                        .query(FieldValue.of(keyword))
-//                        .fuzziness("AUTO")))
-//                .build();
 
         SearchRequest request = new SearchRequest.Builder()
             .index(indexName)
@@ -53,15 +41,15 @@ public class LiquorSearchService {
 
         SearchResponse<LiquorES> response = null;
         try {
-            log.info("호출"+ keyword);
+            log.info("opensearch 요청: "+ keyword);
 
             response = openSearchClient.search(request, LiquorES.class);
             for (Hit<LiquorES> hit : response.hits().hits()) {
                 resultList.add(hit.source());
-
             }
-                log.info("검색 결과 수"+resultList.size());
-            log.info("검색 결과"+ resultList);
+
+            log.info("opensearch 응답: "+ resultList);
+
             return resultList;
         } catch (IOException e) {
             throw new RuntimeException(e);

--- a/src/main/java/team_alcoholic/jumo_server/domain/liquorsearch/service/LiquorSearchService.java
+++ b/src/main/java/team_alcoholic/jumo_server/domain/liquorsearch/service/LiquorSearchService.java
@@ -26,7 +26,7 @@ public class LiquorSearchService {
 
     public List<LiquorES> search(String keyword) {
 
-        log.info("들어온 키워드: "+ keyword);
+        log.info("검색어: "+ keyword);
 
         List<LiquorES> resultList = new ArrayList<>();
 

--- a/src/main/resources/application-local.properties
+++ b/src/main/resources/application-local.properties
@@ -32,7 +32,7 @@ spring.datasource.password=${DB_PASSWORD}
 spring.datasource.driver-class-name=${DB_DRIVER}
 
 # Hibernate settings
-spring.jpa.hibernate.ddl-auto=update
+spring.jpa.hibernate.ddl-auto=none
 spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQLDialect
 


### PR DESCRIPTION
## 🚀 완료한 기능 혹은 수정 기능
**Jira 티켓: [BYOB-205]**

<br>

## 🔨 작업 사항 
**OpenSearch에서의 주류 검색 방식 변경**
: 기존에는 nori tokenizer를 적용하도록 인덱스를 구성했지만, 주류 데이터 특성 상 주류명이 대부분 외래어 고유명사이기 때문에 형태소 분석이 의미가 없었음. 따라서 고유명사의 검색에 적합하도록 tokenizer를 다시 설정함.
- 한글 자소 분리 필터: ICU normalizer를 사용해 자소 분리
- Ngram 필터: 검색 자동완성을 위해 Ngram 필터 적용
결과적으로 기존보다 검색 성능 개선됨

[BYOB-205]: https://swm-alcoholic.atlassian.net/browse/BYOB-205?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ