### PR TITLE
[BYOB-219] Aroma 도메인 API v2 구현

### DIFF
--- a/src/main/java/team_alcoholic/jumo_server/v2/aroma/controller/AromaController.java
+++ b/src/main/java/team_alcoholic/jumo_server/v2/aroma/controller/AromaController.java
@@ -1,0 +1,28 @@
+package team_alcoholic.jumo_server.v2.aroma.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import team_alcoholic.jumo_server.v2.aroma.dto.AromaRes;
+import team_alcoholic.jumo_server.v2.aroma.service.AromaService;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("v2/aromas")
+@RequiredArgsConstructor
+public class AromaController {
+
+    private final AromaService aromaService;
+
+    @GetMapping("/similar")
+    public List<AromaRes> getSimilarAromas(
+        @RequestParam Long aromaId,
+        @RequestParam(required = false) List<Long> exclude,
+        @RequestParam(defaultValue = "5") int limit
+    ) {
+        return aromaService.findSimilarAromas(aromaId, exclude, limit);
+    }
+}

--- a/src/main/java/team_alcoholic/jumo_server/v2/aroma/controller/AromaController.java
+++ b/src/main/java/team_alcoholic/jumo_server/v2/aroma/controller/AromaController.java
@@ -25,4 +25,7 @@ public class AromaController {
     ) {
         return aromaService.findSimilarAromas(aromaId, exclude, limit);
     }
+
+    // GET /aromas/ai/{liquorId} -> 추후 구현
+    // POST /aromas -> 추후 구현
 }

--- a/src/main/java/team_alcoholic/jumo_server/v2/aroma/dto/AromaRes.java
+++ b/src/main/java/team_alcoholic/jumo_server/v2/aroma/dto/AromaRes.java
@@ -1,0 +1,18 @@
+package team_alcoholic.jumo_server.v2.aroma.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+import team_alcoholic.jumo_server.v2.aroma.domain.Aroma;
+
+@Getter @Setter
+public class AromaRes {
+    private Long id;
+    private String name;
+
+    public static AromaRes from(Aroma aroma) {
+        AromaRes aromaRes = new AromaRes();
+        aromaRes.setId(aroma.getId());
+        aromaRes.setName(aroma.getName());
+        return aromaRes;
+    }
+}

--- a/src/main/java/team_alcoholic/jumo_server/v2/aroma/repository/AromaSimilarityRepository.java
+++ b/src/main/java/team_alcoholic/jumo_server/v2/aroma/repository/AromaSimilarityRepository.java
@@ -1,0 +1,24 @@
+package team_alcoholic.jumo_server.v2.aroma.repository;
+
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import team_alcoholic.jumo_server.v2.aroma.domain.Aroma;
+import team_alcoholic.jumo_server.v2.aroma.domain.AromaSimilarity;
+
+import java.util.List;
+
+public interface AromaSimilarityRepository extends JpaRepository<AromaSimilarity, Long> {
+
+    /**
+     * AromaSimilarity를 바탕으로 aroma와 유사한 Aroma 목록을 조회하는 메서드.
+     * fetch join을 사용해 연관 Aroma 엔티티까지 즉시 로딩
+     * @param aromaId
+     * @param exclude
+     * @param pageable
+     */
+    @Query("select ars from AromaSimilarity ars join fetch ars.similarAroma " +
+        "where ars.aroma.id = :aromaId and (:exclude is null or ars.similarAroma.id not in :exclude) " +
+        "order by ars.similarity desc")
+    List<AromaSimilarity> findAromaSimilarityByAroma(Long aromaId, List<Long> exclude, Pageable pageable);
+}

--- a/src/main/java/team_alcoholic/jumo_server/v2/aroma/service/AromaService.java
+++ b/src/main/java/team_alcoholic/jumo_server/v2/aroma/service/AromaService.java
@@ -1,0 +1,35 @@
+package team_alcoholic.jumo_server.v2.aroma.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import team_alcoholic.jumo_server.v2.aroma.domain.Aroma;
+import team_alcoholic.jumo_server.v2.aroma.domain.AromaSimilarity;
+import team_alcoholic.jumo_server.v2.aroma.dto.AromaRes;
+import team_alcoholic.jumo_server.v2.aroma.repository.AromaSimilarityRepository;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class AromaService {
+
+    private final AromaSimilarityRepository aromaSimilarityRepository;
+
+    /**
+     * 유사 Aroma 목록을 조회하는 메서드
+     * aroma와 유사한 Aroma 목록을 받아와서 AromaRes 목록으로 변환
+     * @param aromaId
+     * @param exclude
+     * @param limit
+     */
+    public List<AromaRes> findSimilarAromas(Long aromaId, List<Long> exclude, int limit) {
+        List<AromaSimilarity> result = aromaSimilarityRepository.findAromaSimilarityByAroma(aromaId, exclude, PageRequest.of(0, limit));
+        ArrayList<AromaRes> similarAromas = new ArrayList<>();
+        for (AromaSimilarity similarAroma : result) {
+            similarAromas.add(AromaRes.from(similarAroma.getSimilarAroma()));
+        }
+        return similarAromas;
+    }
+}

--- a/src/main/java/team_alcoholic/jumo_server/v2/aroma/service/AromaService.java
+++ b/src/main/java/team_alcoholic/jumo_server/v2/aroma/service/AromaService.java
@@ -3,7 +3,6 @@ package team_alcoholic.jumo_server.v2.aroma.service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
-import team_alcoholic.jumo_server.v2.aroma.domain.Aroma;
 import team_alcoholic.jumo_server.v2.aroma.domain.AromaSimilarity;
 import team_alcoholic.jumo_server.v2.aroma.dto.AromaRes;
 import team_alcoholic.jumo_server.v2.aroma.repository.AromaSimilarityRepository;


### PR DESCRIPTION
## 🚀 Jira 티켓
**[BYOB-219]**

<br>

## 🔨 작업 사항 

### 1. 유사 아로마 추천 API v2 구현
기존 유사 아로마 추천 API를 변경된 테이블 구조에 맞게 수정한 v2 API를 구현함.

### 2. 구현하지 못한 부분
**1. GPT 기반 주류 아로마 추천 API**
**2. 사용자 커스텀 아로마 API**
aroma 테이블과 custom_aroma 테이블을 함께 관리할 방법을 먼저 정하고 나서 구현할 계획

[BYOB-219]: https://swm-alcoholic.atlassian.net/browse/BYOB-219?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
	- 향에 대한 유사한 향을 검색하는 기능 추가.
	- 향 정보 전송을 위한 DTO 클래스 `AromaRes` 도입.
- **버그 수정**
	- N/A
- **문서화**
	- N/A
- **리팩터링**
	- N/A
- **스타일**
	- N/A
- **테스트**
	- N/A
- **잡일**
	- N/A
- **되돌리기**
	- N/A

<!-- end of auto-generated comment: release notes by coderabbit.ai -->