### PR TITLE
[BYOB-220] Note 도메인 API 구현: 노트 작성 및 상세조회 API

### DIFF
--- a/src/main/java/team_alcoholic/jumo_server/global/common/service/CommonUtilService.java
+++ b/src/main/java/team_alcoholic/jumo_server/global/common/service/CommonUtilService.java
@@ -1,0 +1,48 @@
+package team_alcoholic.jumo_server.global.common.service;
+
+import io.awspring.cloud.s3.S3Template;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class CommonUtilService {
+
+    @Value("${spring.cloud.aws.s3.bucket}")
+    private String s3Bucket;
+
+    @Value("${spring.cloud.aws.s3.uriprefix}")
+    private String s3Endpoint;
+
+    private final S3Template s3Template;
+
+    /**
+     * 파일을 S3에 업로드하는 메서드
+     * @param imageFile "pathname/" 형식으로 전달
+     * @throws IOException
+     */
+    public String uploadImageToS3(MultipartFile imageFile, String path) throws IOException {
+        // 파일 이름 설정: 현재시간 + UUID + 확장자
+        String originalFilename = imageFile.getOriginalFilename();
+        int idx = originalFilename.lastIndexOf('.');
+        String ext = (idx == -1) ? "" : originalFilename.substring(idx);
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyyMMdd_HHmmss");
+        String filename = path + LocalDateTime.now().format(formatter) + "_" + UUID.randomUUID();
+        String newFilename = filename + ext;
+
+        // S3에 파일 업로드
+        InputStream inputStream = imageFile.getInputStream();
+        s3Template.upload(s3Bucket, newFilename, inputStream);
+
+        // 접근 url 반환
+        return s3Endpoint + newFilename;
+    }
+}

--- a/src/main/java/team_alcoholic/jumo_server/v1/liquor/controller/LiquorController.java
+++ b/src/main/java/team_alcoholic/jumo_server/v1/liquor/controller/LiquorController.java
@@ -7,8 +7,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.web.bind.annotation.*;
-import team_alcoholic.jumo_server.v1.liquor.dto.LiquorPostDto;
-import team_alcoholic.jumo_server.v1.liquor.dto.LiquorResDto;
+import team_alcoholic.jumo_server.v1.liquor.dto.LiquorCreateReq;
+import team_alcoholic.jumo_server.v1.liquor.dto.LiquorRes;
 import team_alcoholic.jumo_server.v1.liquor.service.LiquorService;
 import team_alcoholic.jumo_server.v1.user.domain.User;
 import team_alcoholic.jumo_server.v1.user.service.UserServiceV1;
@@ -25,13 +25,13 @@ public class LiquorController {
     private final UserServiceV1 userService;
 
     @GetMapping("{id}")
-    public LiquorResDto getLiquorById(@PathVariable("id") Long id) {
+    public LiquorRes getLiquorById(@PathVariable("id") Long id) {
         return liquorService.findLiquorById(id);
     }
 
     @PostMapping
     public ResponseEntity<Long> createLiquor(
-            @Valid @RequestBody LiquorPostDto liquorPostDto,
+            @Valid @RequestBody LiquorCreateReq liquorCreateReqDto,
             @AuthenticationPrincipal OAuth2User oAuth2User
     ) {
 
@@ -42,7 +42,7 @@ public class LiquorController {
 
         long userId = Long.parseLong(Objects.requireNonNull(oAuth2User.getAttribute("id")).toString());
         User user = userService.findUserById(userId);
-        Long createdLiquorId = liquorService.saveLiquor(liquorPostDto, user);
+        Long createdLiquorId = liquorService.saveLiquor(liquorCreateReqDto, user);
         return new ResponseEntity<>(createdLiquorId, HttpStatus.CREATED);
     }
 

--- a/src/main/java/team_alcoholic/jumo_server/v1/liquor/dto/LiquorCreateReq.java
+++ b/src/main/java/team_alcoholic/jumo_server/v1/liquor/dto/LiquorCreateReq.java
@@ -9,7 +9,7 @@ import lombok.Getter;
 
 @Getter
 @Builder
-public class LiquorPostDto {
+public class LiquorCreateReq {
     @NotBlank(message = "주류명은 필수입니다")
     @Size(max = 200, message = "주류명은 200자를 초과할 수 없습니다")
     private String koName;

--- a/src/main/java/team_alcoholic/jumo_server/v1/liquor/dto/LiquorRes.java
+++ b/src/main/java/team_alcoholic/jumo_server/v1/liquor/dto/LiquorRes.java
@@ -5,7 +5,7 @@ import team_alcoholic.jumo_server.v1.liquor.domain.Liquor;
 import team_alcoholic.jumo_server.v1.tastingnote.dto.AiNotesResDTO;
 import team_alcoholic.jumo_server.v1.user.dto.UserRes;
 
-public record LiquorResDto(
+public record LiquorRes(
         Long id,
         String thumbnailImageUrl,
         String koName,
@@ -28,11 +28,11 @@ public record LiquorResDto(
 ) {
 
     @Builder
-    public LiquorResDto {
+    public LiquorRes {
     }
 
-    public static LiquorResDto fromEntity(Liquor liquor) {
-        return LiquorResDto.builder()
+    public static LiquorRes from(Liquor liquor) {
+        return LiquorRes.builder()
                 .id(liquor.getId())
                 .thumbnailImageUrl(liquor.getThumbnailImageUrl())
                 .koName(liquor.getKoName())

--- a/src/main/java/team_alcoholic/jumo_server/v1/liquor/service/LiquorService.java
+++ b/src/main/java/team_alcoholic/jumo_server/v1/liquor/service/LiquorService.java
@@ -3,8 +3,8 @@ package team_alcoholic.jumo_server.v1.liquor.service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import team_alcoholic.jumo_server.v1.liquor.domain.Liquor;
-import team_alcoholic.jumo_server.v1.liquor.dto.LiquorPostDto;
-import team_alcoholic.jumo_server.v1.liquor.dto.LiquorResDto;
+import team_alcoholic.jumo_server.v1.liquor.dto.LiquorCreateReq;
+import team_alcoholic.jumo_server.v1.liquor.dto.LiquorRes;
 import team_alcoholic.jumo_server.v1.liquor.exception.LiquorNotFoundException;
 import team_alcoholic.jumo_server.v1.liquor.repository.LiquorRepository;
 import team_alcoholic.jumo_server.v1.user.domain.User;
@@ -18,19 +18,19 @@ public class LiquorService {
 
     private final LiquorRepository liquorRepository;
 
-    public LiquorResDto findLiquorById(Long id) {
+    public LiquorRes findLiquorById(Long id) {
         Liquor liquor = liquorRepository.findById(id).orElseThrow(
                 () -> new LiquorNotFoundException(id)
         );
-        return LiquorResDto.fromEntity(liquor);
+        return LiquorRes.from(liquor);
     }
 
-    public Long saveLiquor(LiquorPostDto liquorPostDto, User user) {
-        Liquor newLiquor = convertToEntity(liquorPostDto, user);
+    public Long saveLiquor(LiquorCreateReq liquorCreateReqDto, User user) {
+        Liquor newLiquor = convertToEntity(liquorCreateReqDto, user);
         return liquorRepository.save(newLiquor).getId();
     }
 
-    private Liquor convertToEntity(LiquorPostDto dto, User user) {
+    private Liquor convertToEntity(LiquorCreateReq dto, User user) {
         return Liquor.builder()
                 .koName(dto.getKoName())
                 .abv(formatAbv(dto.getAbv()))

--- a/src/main/java/team_alcoholic/jumo_server/v1/tastingnote/dto/TastingNoteResDTO.java
+++ b/src/main/java/team_alcoholic/jumo_server/v1/tastingnote/dto/TastingNoteResDTO.java
@@ -1,13 +1,13 @@
 package team_alcoholic.jumo_server.v1.tastingnote.dto;
 
 import lombok.Builder;
-import team_alcoholic.jumo_server.v1.liquor.dto.LiquorResDto;
+import team_alcoholic.jumo_server.v1.liquor.dto.LiquorRes;
 import team_alcoholic.jumo_server.v1.tastingnote.domain.TastingNote;
 import team_alcoholic.jumo_server.v1.user.dto.UserRes;
 
 public record TastingNoteResDTO(
         Long id,
-        LiquorResDto liquor,
+        LiquorRes liquor,
         Integer noseScore,
         Integer palateScore,
         Integer finishScore,
@@ -31,7 +31,7 @@ public record TastingNoteResDTO(
     public static TastingNoteResDTO fromEntity(TastingNote tastingNote) {
         return TastingNoteResDTO.builder()
                 .id(tastingNote.getId())
-                .liquor(LiquorResDto.fromEntity(tastingNote.getLiquor()))
+                .liquor(LiquorRes.from(tastingNote.getLiquor()))
                 .noseScore(tastingNote.getNoseScore())
                 .palateScore(tastingNote.getPalateScore())
                 .finishScore(tastingNote.getFinishScore())

--- a/src/main/java/team_alcoholic/jumo_server/v1/tastingnote/repository/TastingNoteRepositoryV1.java
+++ b/src/main/java/team_alcoholic/jumo_server/v1/tastingnote/repository/TastingNoteRepositoryV1.java
@@ -9,7 +9,7 @@ import team_alcoholic.jumo_server.v1.tastingnote.domain.TastingNote;
 import java.util.List;
 import java.util.UUID;
 
-public interface TastingNoteRepository extends JpaRepository<TastingNote, Long> {
+public interface TastingNoteRepositoryV1 extends JpaRepository<TastingNote, Long> {
 
     @Query("SELECT tn FROM TastingNote tn WHERE tn.liquor.id = :liquorId ORDER BY tn.createdAt DESC")
     @EntityGraph(attributePaths = {"liquor", "user"})

--- a/src/main/java/team_alcoholic/jumo_server/v1/tastingnote/service/TastingNoteService.java
+++ b/src/main/java/team_alcoholic/jumo_server/v1/tastingnote/service/TastingNoteService.java
@@ -14,7 +14,7 @@ import team_alcoholic.jumo_server.v1.tastingnote.domain.TastingNote;
 import team_alcoholic.jumo_server.v1.tastingnote.dto.*;
 import team_alcoholic.jumo_server.v1.tastingnote.exception.TastingNoteNotFoundException;
 import team_alcoholic.jumo_server.v1.tastingnote.repository.AiTastingNoteRepository;
-import team_alcoholic.jumo_server.v1.tastingnote.repository.TastingNoteRepository;
+import team_alcoholic.jumo_server.v1.tastingnote.repository.TastingNoteRepositoryV1;
 import team_alcoholic.jumo_server.v1.tastingnote.repository.TastingNoteSimilarityVectorsRepository;
 import team_alcoholic.jumo_server.v1.user.domain.User;
 
@@ -28,7 +28,7 @@ import java.util.stream.Collectors;
 public class TastingNoteService {
 
     private final TastingNoteSimilarityVectorsRepository tastingNoteSimilarityVectorsRepository;
-    private final TastingNoteRepository tastingNoteRepository;
+    private final TastingNoteRepositoryV1 tastingNoteRepositoryV1;
     private final LiquorRepository liquorRepository;
     private final AiTastingNoteRepository aiTastingNoteRepository;
     private final ChatClient chatClient;
@@ -54,7 +54,7 @@ public class TastingNoteService {
                 .orElseThrow(() -> new LiquorNotFoundException(saveTastingNoteReqDTO.getLiquorId()));
         TastingNote newTastingNote = convertToEntity(saveTastingNoteReqDTO, liquor, user);
 
-        return tastingNoteRepository.save(newTastingNote).getId();
+        return tastingNoteRepositoryV1.save(newTastingNote).getId();
     }
 
     private TastingNote convertToEntity(SaveTastingNoteReqDTO dto, Liquor liquor, User user) {
@@ -76,7 +76,7 @@ public class TastingNoteService {
     }
 
     public TastingNoteResDTO getTastingNoteById(Long id) {
-        TastingNote tastingNote = tastingNoteRepository.findById(id)
+        TastingNote tastingNote = tastingNoteRepositoryV1.findById(id)
                 .orElseThrow(() -> new TastingNoteNotFoundException(id));
 
         return TastingNoteResDTO.fromEntity(tastingNote);
@@ -86,7 +86,7 @@ public class TastingNoteService {
      * Liquor id에 해당하는 테이스팅 노트 목록을 반환
      */
     public List<TastingNoteResDTO> getTastingNoteListByLiquor(Long liquor) {
-        List<TastingNote> result = tastingNoteRepository.findTastingNotesByLiquorId(liquor);
+        List<TastingNote> result = tastingNoteRepositoryV1.findTastingNotesByLiquorId(liquor);
         return result.stream().map(TastingNoteResDTO::fromEntity).collect(Collectors.toList());
     }
 
@@ -95,7 +95,7 @@ public class TastingNoteService {
      */
     public List<TastingNoteResDTO> getTastingNoteListByUser(String userUuid) {
         UUID uuid = UUID.fromString(userUuid);
-        List<TastingNote> result = tastingNoteRepository.findTastingNotesByUserUuId(uuid);
+        List<TastingNote> result = tastingNoteRepositoryV1.findTastingNotesByUserUuId(uuid);
         return result.stream().map(TastingNoteResDTO::fromEntity).collect(Collectors.toList());
     }
 
@@ -114,7 +114,7 @@ public class TastingNoteService {
 
     @Transactional
     public Long updateTastingNote(Long id, UpdateTastingNoteReqDTO updateTastingNoteReqDTO, User user) throws AccessDeniedException {
-        TastingNote tastingNote = tastingNoteRepository.findById(id)
+        TastingNote tastingNote = tastingNoteRepositoryV1.findById(id)
                 .orElseThrow(() -> new TastingNoteNotFoundException(id));
 
         if (!tastingNote.getUser().getId().equals(user.getId())) {

--- a/src/main/java/team_alcoholic/jumo_server/v2/aroma/repository/AromaRepository.java
+++ b/src/main/java/team_alcoholic/jumo_server/v2/aroma/repository/AromaRepository.java
@@ -1,0 +1,7 @@
+package team_alcoholic.jumo_server.v2.aroma.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import team_alcoholic.jumo_server.v2.aroma.domain.Aroma;
+
+public interface AromaRepository extends JpaRepository<Aroma, Long> {
+}

--- a/src/main/java/team_alcoholic/jumo_server/v2/note/controller/NoteController.java
+++ b/src/main/java/team_alcoholic/jumo_server/v2/note/controller/NoteController.java
@@ -1,6 +1,5 @@
 package team_alcoholic.jumo_server.v2.note.controller;
 
-import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.oauth2.core.user.OAuth2User;
@@ -12,7 +11,7 @@ import team_alcoholic.jumo_server.v2.note.dto.response.PurchaseNoteRes;
 import team_alcoholic.jumo_server.v2.note.dto.response.TastingNoteRes;
 import team_alcoholic.jumo_server.v2.note.service.NoteService;
 
-import java.time.LocalDateTime;
+import java.io.IOException;
 
 @RestController
 @RequestMapping("v2/notes")
@@ -30,7 +29,7 @@ public class NoteController {
     public PurchaseNoteRes createPurchaseNote(
         @AuthenticationPrincipal OAuth2User oAuth2User,
         @ModelAttribute PurchaseNoteCreateReq noteCreateReq
-    ) {
+    ) throws IOException {
         if (oAuth2User == null) { throw new UnauthorizedException("로그인이 필요합니다."); }
         return noteService.createPurchaseNote(oAuth2User.getAttribute("userUuid"), noteCreateReq);
     }
@@ -44,7 +43,7 @@ public class NoteController {
     public TastingNoteRes createTastingNote(
         @AuthenticationPrincipal OAuth2User oAuth2User,
         @ModelAttribute TastingNoteCreateReq noteCreateReq
-    ) {
+    ) throws IOException {
         if (oAuth2User == null) { throw new UnauthorizedException("로그인이 필요합니다."); }
         return noteService.createTastingNote(oAuth2User.getAttribute("userUuid"), noteCreateReq);
     }

--- a/src/main/java/team_alcoholic/jumo_server/v2/note/controller/NoteController.java
+++ b/src/main/java/team_alcoholic/jumo_server/v2/note/controller/NoteController.java
@@ -7,6 +7,8 @@ import org.springframework.web.bind.annotation.*;
 import team_alcoholic.jumo_server.global.error.exception.UnauthorizedException;
 import team_alcoholic.jumo_server.v2.note.dto.request.PurchaseNoteCreateReq;
 import team_alcoholic.jumo_server.v2.note.dto.request.TastingNoteCreateReq;
+import team_alcoholic.jumo_server.v2.note.dto.response.GeneralNoteRes;
+import team_alcoholic.jumo_server.v2.note.dto.response.NoteRes;
 import team_alcoholic.jumo_server.v2.note.dto.response.PurchaseNoteRes;
 import team_alcoholic.jumo_server.v2.note.dto.response.TastingNoteRes;
 import team_alcoholic.jumo_server.v2.note.service.NoteService;
@@ -46,5 +48,14 @@ public class NoteController {
     ) throws IOException {
         if (oAuth2User == null) { throw new UnauthorizedException("로그인이 필요합니다."); }
         return noteService.createTastingNote(oAuth2User.getAttribute("userUuid"), noteCreateReq);
+    }
+
+    /**
+     * 노트 상세 조회 API
+     * @param id 조회하려는 노트의 id
+     */
+    @GetMapping("/{id}")
+    public GeneralNoteRes getNoteById(@PathVariable Long id) {
+        return noteService.getNoteById(id);
     }
 }

--- a/src/main/java/team_alcoholic/jumo_server/v2/note/controller/NoteController.java
+++ b/src/main/java/team_alcoholic/jumo_server/v2/note/controller/NoteController.java
@@ -46,10 +46,6 @@ public class NoteController {
         @ModelAttribute TastingNoteCreateReq noteCreateReq
     ) {
         if (oAuth2User == null) { throw new UnauthorizedException("로그인이 필요합니다."); }
-
-        TastingNoteRes tastingNoteRes = noteService.createTastingNote(oAuth2User.getAttribute("userUuid"), noteCreateReq);
-        System.out.println("Controller: " + tastingNoteRes);
-        return tastingNoteRes;
-//        return noteService.createTastingNote(oAuth2User.getAttribute("userUuid"), noteCreateReq);
+        return noteService.createTastingNote(oAuth2User.getAttribute("userUuid"), noteCreateReq);
     }
 }

--- a/src/main/java/team_alcoholic/jumo_server/v2/note/controller/NoteController.java
+++ b/src/main/java/team_alcoholic/jumo_server/v2/note/controller/NoteController.java
@@ -1,0 +1,55 @@
+package team_alcoholic.jumo_server.v2.note.controller;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.web.bind.annotation.*;
+import team_alcoholic.jumo_server.global.error.exception.UnauthorizedException;
+import team_alcoholic.jumo_server.v2.note.dto.request.PurchaseNoteCreateReq;
+import team_alcoholic.jumo_server.v2.note.dto.request.TastingNoteCreateReq;
+import team_alcoholic.jumo_server.v2.note.dto.response.PurchaseNoteRes;
+import team_alcoholic.jumo_server.v2.note.dto.response.TastingNoteRes;
+import team_alcoholic.jumo_server.v2.note.service.NoteService;
+
+import java.time.LocalDateTime;
+
+@RestController
+@RequestMapping("v2/notes")
+@RequiredArgsConstructor
+public class NoteController {
+
+    private final NoteService noteService;
+
+    /**
+     * 구매 노트 생성 API
+     * @param oAuth2User
+     * @param noteCreateReq
+     */
+    @PostMapping("/purchase")
+    public PurchaseNoteRes createPurchaseNote(
+        @AuthenticationPrincipal OAuth2User oAuth2User,
+        @ModelAttribute PurchaseNoteCreateReq noteCreateReq
+    ) {
+        if (oAuth2User == null) { throw new UnauthorizedException("로그인이 필요합니다."); }
+        return noteService.createPurchaseNote(oAuth2User.getAttribute("userUuid"), noteCreateReq);
+    }
+
+    /**
+     * 감상 노트 생성 API
+     * @param oAuth2User
+     * @param noteCreateReq
+     */
+    @PostMapping("/tasting")
+    public TastingNoteRes createTastingNote(
+        @AuthenticationPrincipal OAuth2User oAuth2User,
+        @ModelAttribute TastingNoteCreateReq noteCreateReq
+    ) {
+        if (oAuth2User == null) { throw new UnauthorizedException("로그인이 필요합니다."); }
+
+        TastingNoteRes tastingNoteRes = noteService.createTastingNote(oAuth2User.getAttribute("userUuid"), noteCreateReq);
+        System.out.println("Controller: " + tastingNoteRes);
+        return tastingNoteRes;
+//        return noteService.createTastingNote(oAuth2User.getAttribute("userUuid"), noteCreateReq);
+    }
+}

--- a/src/main/java/team_alcoholic/jumo_server/v2/note/domain/Note.java
+++ b/src/main/java/team_alcoholic/jumo_server/v2/note/domain/Note.java
@@ -6,6 +6,9 @@ import team_alcoholic.jumo_server.v1.liquor.domain.Liquor;
 import team_alcoholic.jumo_server.global.common.domain.BaseTimeEntity;
 import team_alcoholic.jumo_server.v2.user.domain.NewUser;
 
+import java.util.ArrayList;
+import java.util.List;
+
 
 @Entity
 @Getter
@@ -24,8 +27,8 @@ public abstract class Note extends BaseTimeEntity {
     @JoinColumn(name = "liquor_id")
     private Liquor liquor;
 
-//    @OneToMany(mappedBy = "note", fetch = FetchType.LAZY)
-//    private List<NoteImage> noteImages = new ArrayList<>();
+    @OneToMany(mappedBy = "note", fetch = FetchType.LAZY)
+    private List<NoteImage> noteImages = new ArrayList<>();
 
     protected Note() {}
     public Note(NewUser user, Liquor liquor) {

--- a/src/main/java/team_alcoholic/jumo_server/v2/note/domain/Note.java
+++ b/src/main/java/team_alcoholic/jumo_server/v2/note/domain/Note.java
@@ -3,8 +3,9 @@ package team_alcoholic.jumo_server.v2.note.domain;
 import jakarta.persistence.*;
 import lombok.Getter;
 import team_alcoholic.jumo_server.v1.liquor.domain.Liquor;
-import team_alcoholic.jumo_server.v1.user.domain.User;
 import team_alcoholic.jumo_server.global.common.domain.BaseTimeEntity;
+import team_alcoholic.jumo_server.v2.user.domain.NewUser;
+
 
 @Entity
 @Getter
@@ -15,13 +16,20 @@ public abstract class Note extends BaseTimeEntity {
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
-    private User user;
+    private NewUser user;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "liquor_id")
     private Liquor liquor;
 
-//    private NoteImage noteImage
+//    @OneToMany(mappedBy = "note", fetch = FetchType.LAZY)
+//    private List<NoteImage> noteImages = new ArrayList<>();
+
+    protected Note() {}
+    public Note(NewUser user, Liquor liquor) {
+        this.user = user;
+        this.liquor = liquor;
+    }
 }

--- a/src/main/java/team_alcoholic/jumo_server/v2/note/domain/NoteAroma.java
+++ b/src/main/java/team_alcoholic/jumo_server/v2/note/domain/NoteAroma.java
@@ -13,8 +13,15 @@ public class NoteAroma extends BaseTimeEntity {
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    private Note note;
+    private TastingNote note;
 
     @ManyToOne(fetch = FetchType.LAZY)
     private Aroma aroma;
+
+    protected NoteAroma() {}
+    public NoteAroma(TastingNote note, Aroma aroma) {
+        this.note = note;
+        this.note.getNoteAromas().add(this);
+        this.aroma = aroma;
+    }
 }

--- a/src/main/java/team_alcoholic/jumo_server/v2/note/domain/NoteImage.java
+++ b/src/main/java/team_alcoholic/jumo_server/v2/note/domain/NoteImage.java
@@ -16,4 +16,12 @@ public class NoteImage extends BaseTimeEntity {
 
     private String fileName;
     private String fileUrl;
+
+    protected NoteImage() {}
+    public NoteImage(Note note, String fileName, String fileUrl) {
+        this.note = note;
+        this.note.getNoteImages().add(this);
+        this.fileName = fileName;
+        this.fileUrl = fileUrl;
+    }
 }

--- a/src/main/java/team_alcoholic/jumo_server/v2/note/domain/PurchaseNote.java
+++ b/src/main/java/team_alcoholic/jumo_server/v2/note/domain/PurchaseNote.java
@@ -2,17 +2,16 @@ package team_alcoholic.jumo_server.v2.note.domain;
 
 import jakarta.persistence.DiscriminatorValue;
 import jakarta.persistence.Entity;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
+import team_alcoholic.jumo_server.v1.liquor.domain.Liquor;
+import team_alcoholic.jumo_server.v2.note.dto.request.PurchaseNoteCreateReq;
+import team_alcoholic.jumo_server.v2.user.domain.NewUser;
 
 import java.time.LocalDate;
 
 @Entity
 @DiscriminatorValue(value = "PURCHASE")
 @Getter
-@NoArgsConstructor
-@AllArgsConstructor
 public class PurchaseNote extends Note {
 
     private LocalDate purchaseAt;
@@ -20,4 +19,14 @@ public class PurchaseNote extends Note {
     private Integer price;
     private Integer volume;
     private String content;
+
+    protected PurchaseNote() {}
+    public PurchaseNote(PurchaseNoteCreateReq noteCreateReq, NewUser user, Liquor liquor) {
+        super(user, liquor);
+        this.purchaseAt = noteCreateReq.getPurchaseAt();
+        this.place = noteCreateReq.getPlace();
+        this.price = noteCreateReq.getPrice();
+        this.volume = noteCreateReq.getVolume();
+        this.content = noteCreateReq.getContent();
+    }
 }

--- a/src/main/java/team_alcoholic/jumo_server/v2/note/domain/TastingNote.java
+++ b/src/main/java/team_alcoholic/jumo_server/v2/note/domain/TastingNote.java
@@ -2,17 +2,16 @@ package team_alcoholic.jumo_server.v2.note.domain;
 
 import jakarta.persistence.DiscriminatorValue;
 import jakarta.persistence.Entity;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
+import team_alcoholic.jumo_server.v1.liquor.domain.Liquor;
+import team_alcoholic.jumo_server.v2.note.dto.request.TastingNoteCreateReq;
+import team_alcoholic.jumo_server.v2.user.domain.NewUser;
 
 import java.time.LocalDate;
 
 @Entity(name = "tasting_note_new")
 @DiscriminatorValue(value = "TASTING")
 @Getter
-@NoArgsConstructor
-@AllArgsConstructor
 public class TastingNote extends Note {
 
     private LocalDate tastingAt;
@@ -24,4 +23,18 @@ public class TastingNote extends Note {
     private String nose;
     private String palate;
     private String finish;
+
+    protected TastingNote() {}
+    public TastingNote(TastingNoteCreateReq noteCreateReq, NewUser user, Liquor liquor) {
+        super(user, liquor);
+        this.tastingAt = noteCreateReq.getTastingAt();
+        this.method = noteCreateReq.getMethod();
+        this.place = noteCreateReq.getPlace();
+        this.score = noteCreateReq.getScore();
+        this.isDetail = noteCreateReq.getIsDetail();
+        this.content = noteCreateReq.getContent();
+        this.nose = noteCreateReq.getNose();
+        this.palate = noteCreateReq.getPalate();
+        this.finish = noteCreateReq.getFinish();
+    }
 }

--- a/src/main/java/team_alcoholic/jumo_server/v2/note/domain/TastingNote.java
+++ b/src/main/java/team_alcoholic/jumo_server/v2/note/domain/TastingNote.java
@@ -2,12 +2,16 @@ package team_alcoholic.jumo_server.v2.note.domain;
 
 import jakarta.persistence.DiscriminatorValue;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.OneToMany;
 import lombok.Getter;
 import team_alcoholic.jumo_server.v1.liquor.domain.Liquor;
 import team_alcoholic.jumo_server.v2.note.dto.request.TastingNoteCreateReq;
 import team_alcoholic.jumo_server.v2.user.domain.NewUser;
 
 import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity(name = "tasting_note_new")
 @DiscriminatorValue(value = "TASTING")
@@ -23,6 +27,9 @@ public class TastingNote extends Note {
     private String nose;
     private String palate;
     private String finish;
+
+    @OneToMany(mappedBy = "note", fetch = FetchType.LAZY)
+    private List<NoteAroma> noteAromas = new ArrayList<>();
 
     protected TastingNote() {}
     public TastingNote(TastingNoteCreateReq noteCreateReq, NewUser user, Liquor liquor) {

--- a/src/main/java/team_alcoholic/jumo_server/v2/note/dto/request/PurchaseNoteCreateReq.java
+++ b/src/main/java/team_alcoholic/jumo_server/v2/note/dto/request/PurchaseNoteCreateReq.java
@@ -1,0 +1,21 @@
+package team_alcoholic.jumo_server.v2.note.dto.request;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Getter @Setter
+public class PurchaseNoteCreateReq {
+
+    private Long liquorId;
+    private List<MultipartFile> noteImages;
+
+    private LocalDate purchaseAt;
+    private String place;
+    private Integer price;
+    private Integer volume;
+    private String content;
+}

--- a/src/main/java/team_alcoholic/jumo_server/v2/note/dto/request/TastingNoteCreateReq.java
+++ b/src/main/java/team_alcoholic/jumo_server/v2/note/dto/request/TastingNoteCreateReq.java
@@ -17,6 +17,7 @@ public class TastingNoteCreateReq {
     private LocalDate tastingAt;
     private String method;
     private String place;
+    private List<Long> noteAromas;
     private Integer score;
     private Boolean isDetail;
 

--- a/src/main/java/team_alcoholic/jumo_server/v2/note/dto/request/TastingNoteCreateReq.java
+++ b/src/main/java/team_alcoholic/jumo_server/v2/note/dto/request/TastingNoteCreateReq.java
@@ -1,0 +1,31 @@
+package team_alcoholic.jumo_server.v2.note.dto.request;
+
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.Setter;
+import team_alcoholic.jumo_server.v2.note.domain.NoteImage;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Getter @Setter
+public class TastingNoteCreateReq {
+
+    private Long liquorId;
+    private List<NoteImage> noteImages;
+
+    private LocalDate tastingAt;
+    private String method;
+    private String place;
+    private Integer score;
+    private Boolean isDetail;
+
+    @Size(max = 1500)
+    private String content;
+    @Size(max = 1500)
+    private String nose;
+    @Size(max = 1500)
+    private String palate;
+    @Size(max = 1500)
+    private String finish;
+}

--- a/src/main/java/team_alcoholic/jumo_server/v2/note/dto/request/TastingNoteCreateReq.java
+++ b/src/main/java/team_alcoholic/jumo_server/v2/note/dto/request/TastingNoteCreateReq.java
@@ -3,7 +3,7 @@ package team_alcoholic.jumo_server.v2.note.dto.request;
 import jakarta.validation.constraints.Size;
 import lombok.Getter;
 import lombok.Setter;
-import team_alcoholic.jumo_server.v2.note.domain.NoteImage;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -12,7 +12,7 @@ import java.util.List;
 public class TastingNoteCreateReq {
 
     private Long liquorId;
-    private List<NoteImage> noteImages;
+    private List<MultipartFile> noteImages;
 
     private LocalDate tastingAt;
     private String method;

--- a/src/main/java/team_alcoholic/jumo_server/v2/note/dto/response/GeneralNoteRes.java
+++ b/src/main/java/team_alcoholic/jumo_server/v2/note/dto/response/GeneralNoteRes.java
@@ -1,0 +1,42 @@
+package team_alcoholic.jumo_server.v2.note.dto.response;
+
+import jakarta.persistence.DiscriminatorValue;
+import lombok.Getter;
+import lombok.Setter;
+import team_alcoholic.jumo_server.v2.note.domain.Note;
+import team_alcoholic.jumo_server.v2.note.domain.PurchaseNote;
+import team_alcoholic.jumo_server.v2.note.domain.TastingNote;
+
+@Getter @Setter
+public class GeneralNoteRes {
+    private String type;
+    private PurchaseNoteRes purchaseNote;
+    private TastingNoteRes tastingNote;
+
+    public static GeneralNoteRes from(Note note) {
+        GeneralNoteRes noteRes = new GeneralNoteRes();
+        if (note instanceof PurchaseNote purchaseNote) {
+            noteRes.setType(purchaseNote.getClass().getAnnotation(DiscriminatorValue.class).value());
+            noteRes.setPurchaseNote(PurchaseNoteRes.from(purchaseNote));
+        }
+        else if (note instanceof TastingNote tastingNote) {
+            noteRes.setType(tastingNote.getClass().getAnnotation(DiscriminatorValue.class).value());
+            noteRes.setTastingNote(TastingNoteRes.from(tastingNote));
+        }
+        return noteRes;
+    }
+
+    public static GeneralNoteRes from(PurchaseNote note) {
+        GeneralNoteRes noteRes = new GeneralNoteRes();
+        noteRes.setType(note.getClass().getAnnotation(DiscriminatorValue.class).value());
+        noteRes.setPurchaseNote(PurchaseNoteRes.from(note));
+        return noteRes;
+    }
+
+    public static GeneralNoteRes from(TastingNote note) {
+        GeneralNoteRes noteRes = new GeneralNoteRes();
+        noteRes.setType(note.getClass().getAnnotation(DiscriminatorValue.class).value());
+        noteRes.setTastingNote(TastingNoteRes.from(note));
+        return noteRes;
+    }
+}

--- a/src/main/java/team_alcoholic/jumo_server/v2/note/dto/response/NoteImageRes.java
+++ b/src/main/java/team_alcoholic/jumo_server/v2/note/dto/response/NoteImageRes.java
@@ -1,0 +1,20 @@
+package team_alcoholic.jumo_server.v2.note.dto.response;
+
+import lombok.Getter;
+import lombok.Setter;
+import team_alcoholic.jumo_server.v2.note.domain.NoteImage;
+
+@Getter @Setter
+public class NoteImageRes {
+    private Long id;
+    private String fileName;
+    private String fileUrl;
+
+    public static NoteImageRes from(NoteImage noteImage) {
+        NoteImageRes noteImageRes = new NoteImageRes();
+        noteImageRes.setId(noteImage.getId());
+        noteImageRes.setFileName(noteImage.getFileName());
+        noteImageRes.setFileUrl(noteImage.getFileUrl());
+        return noteImageRes;
+    }
+}

--- a/src/main/java/team_alcoholic/jumo_server/v2/note/dto/response/NoteRes.java
+++ b/src/main/java/team_alcoholic/jumo_server/v2/note/dto/response/NoteRes.java
@@ -1,0 +1,14 @@
+package team_alcoholic.jumo_server.v2.note.dto.response;
+
+import lombok.Getter;
+import lombok.Setter;
+import team_alcoholic.jumo_server.v1.liquor.dto.LiquorRes;
+import team_alcoholic.jumo_server.v2.user.dto.UserRes;
+
+@Getter @Setter
+public abstract class NoteRes {
+
+    private Long id;
+    private UserRes user;
+    private LiquorRes liquor;
+}

--- a/src/main/java/team_alcoholic/jumo_server/v2/note/dto/response/NoteRes.java
+++ b/src/main/java/team_alcoholic/jumo_server/v2/note/dto/response/NoteRes.java
@@ -5,10 +5,14 @@ import lombok.Setter;
 import team_alcoholic.jumo_server.v1.liquor.dto.LiquorRes;
 import team_alcoholic.jumo_server.v2.user.dto.UserRes;
 
+import java.util.ArrayList;
+import java.util.List;
+
 @Getter @Setter
 public abstract class NoteRes {
 
     private Long id;
     private UserRes user;
     private LiquorRes liquor;
+    private List<NoteImageRes> noteImages = new ArrayList<>();
 }

--- a/src/main/java/team_alcoholic/jumo_server/v2/note/dto/response/PurchaseNoteRes.java
+++ b/src/main/java/team_alcoholic/jumo_server/v2/note/dto/response/PurchaseNoteRes.java
@@ -3,6 +3,7 @@ package team_alcoholic.jumo_server.v2.note.dto.response;
 import lombok.Getter;
 import lombok.Setter;
 import team_alcoholic.jumo_server.v1.liquor.dto.LiquorRes;
+import team_alcoholic.jumo_server.v2.note.domain.NoteImage;
 import team_alcoholic.jumo_server.v2.note.domain.PurchaseNote;
 import team_alcoholic.jumo_server.v2.user.dto.UserRes;
 
@@ -22,6 +23,10 @@ public class PurchaseNoteRes extends NoteRes {
         purchaseNoteRes.setId(note.getId());
         purchaseNoteRes.setUser(UserRes.from(note.getUser()));
         purchaseNoteRes.setLiquor(LiquorRes.from(note.getLiquor()));
+        for (NoteImage noteImage : note.getNoteImages()) {
+            purchaseNoteRes.getNoteImages().add(NoteImageRes.from(noteImage));
+        }
+
         purchaseNoteRes.setPurchaseAt(note.getPurchaseAt());
         purchaseNoteRes.setPlace(note.getPlace());
         purchaseNoteRes.setPrice(note.getPrice());

--- a/src/main/java/team_alcoholic/jumo_server/v2/note/dto/response/PurchaseNoteRes.java
+++ b/src/main/java/team_alcoholic/jumo_server/v2/note/dto/response/PurchaseNoteRes.java
@@ -1,0 +1,32 @@
+package team_alcoholic.jumo_server.v2.note.dto.response;
+
+import lombok.Getter;
+import lombok.Setter;
+import team_alcoholic.jumo_server.v1.liquor.dto.LiquorRes;
+import team_alcoholic.jumo_server.v2.note.domain.PurchaseNote;
+import team_alcoholic.jumo_server.v2.user.dto.UserRes;
+
+import java.time.LocalDate;
+
+@Getter @Setter
+public class PurchaseNoteRes extends NoteRes {
+
+    private LocalDate purchaseAt;
+    private String place;
+    private Integer price;
+    private Integer volume;
+    private String content;
+
+    public static PurchaseNoteRes from(PurchaseNote note) {
+        PurchaseNoteRes purchaseNoteRes = new PurchaseNoteRes();
+        purchaseNoteRes.setId(note.getId());
+        purchaseNoteRes.setUser(UserRes.from(note.getUser()));
+        purchaseNoteRes.setLiquor(LiquorRes.from(note.getLiquor()));
+        purchaseNoteRes.setPurchaseAt(note.getPurchaseAt());
+        purchaseNoteRes.setPlace(note.getPlace());
+        purchaseNoteRes.setPrice(note.getPrice());
+        purchaseNoteRes.setVolume(note.getVolume());
+        purchaseNoteRes.setContent(note.getContent());
+        return purchaseNoteRes;
+    }
+}

--- a/src/main/java/team_alcoholic/jumo_server/v2/note/dto/response/PurchaseNoteRes.java
+++ b/src/main/java/team_alcoholic/jumo_server/v2/note/dto/response/PurchaseNoteRes.java
@@ -1,5 +1,6 @@
 package team_alcoholic.jumo_server.v2.note.dto.response;
 
+import jakarta.persistence.DiscriminatorValue;
 import lombok.Getter;
 import lombok.Setter;
 import team_alcoholic.jumo_server.v1.liquor.dto.LiquorRes;

--- a/src/main/java/team_alcoholic/jumo_server/v2/note/dto/response/TastingNoteRes.java
+++ b/src/main/java/team_alcoholic/jumo_server/v2/note/dto/response/TastingNoteRes.java
@@ -1,0 +1,40 @@
+package team_alcoholic.jumo_server.v2.note.dto.response;
+
+import lombok.Getter;
+import lombok.Setter;
+import team_alcoholic.jumo_server.v1.liquor.dto.LiquorRes;
+import team_alcoholic.jumo_server.v2.note.domain.TastingNote;
+import team_alcoholic.jumo_server.v2.user.dto.UserRes;
+
+import java.time.LocalDate;
+
+@Getter @Setter
+public class TastingNoteRes extends NoteRes{
+
+    private LocalDate tastingAt;
+    private String method;
+    private String place;
+    private Integer score;
+    private Boolean isDetail;
+    private String content;
+    private String nose;
+    private String palate;
+    private String finish;
+
+    public static TastingNoteRes from(TastingNote tastingNote) {
+        TastingNoteRes tastingNoteRes = new TastingNoteRes();
+        tastingNoteRes.setId(tastingNoteRes.getId());
+        tastingNoteRes.setUser(UserRes.from(tastingNote.getUser()));
+        tastingNoteRes.setLiquor(LiquorRes.from(tastingNote.getLiquor()));
+        tastingNoteRes.setTastingAt(tastingNote.getTastingAt());
+        tastingNoteRes.setMethod(tastingNote.getMethod());
+        tastingNoteRes.setPlace(tastingNote.getPlace());
+        tastingNoteRes.setScore(tastingNote.getScore());
+        tastingNoteRes.setContent(tastingNote.getContent());
+        tastingNoteRes.setIsDetail(tastingNote.getIsDetail());
+        tastingNoteRes.setNose(tastingNote.getNose());
+        tastingNoteRes.setPalate(tastingNote.getPalate());
+        tastingNoteRes.setFinish(tastingNote.getFinish());
+        return tastingNoteRes;
+    }
+}

--- a/src/main/java/team_alcoholic/jumo_server/v2/note/dto/response/TastingNoteRes.java
+++ b/src/main/java/team_alcoholic/jumo_server/v2/note/dto/response/TastingNoteRes.java
@@ -3,6 +3,7 @@ package team_alcoholic.jumo_server.v2.note.dto.response;
 import lombok.Getter;
 import lombok.Setter;
 import team_alcoholic.jumo_server.v1.liquor.dto.LiquorRes;
+import team_alcoholic.jumo_server.v2.note.domain.NoteImage;
 import team_alcoholic.jumo_server.v2.note.domain.TastingNote;
 import team_alcoholic.jumo_server.v2.user.dto.UserRes;
 
@@ -21,20 +22,24 @@ public class TastingNoteRes extends NoteRes{
     private String palate;
     private String finish;
 
-    public static TastingNoteRes from(TastingNote tastingNote) {
+    public static TastingNoteRes from(TastingNote note) {
         TastingNoteRes tastingNoteRes = new TastingNoteRes();
         tastingNoteRes.setId(tastingNoteRes.getId());
-        tastingNoteRes.setUser(UserRes.from(tastingNote.getUser()));
-        tastingNoteRes.setLiquor(LiquorRes.from(tastingNote.getLiquor()));
-        tastingNoteRes.setTastingAt(tastingNote.getTastingAt());
-        tastingNoteRes.setMethod(tastingNote.getMethod());
-        tastingNoteRes.setPlace(tastingNote.getPlace());
-        tastingNoteRes.setScore(tastingNote.getScore());
-        tastingNoteRes.setContent(tastingNote.getContent());
-        tastingNoteRes.setIsDetail(tastingNote.getIsDetail());
-        tastingNoteRes.setNose(tastingNote.getNose());
-        tastingNoteRes.setPalate(tastingNote.getPalate());
-        tastingNoteRes.setFinish(tastingNote.getFinish());
+        tastingNoteRes.setUser(UserRes.from(note.getUser()));
+        tastingNoteRes.setLiquor(LiquorRes.from(note.getLiquor()));
+        for (NoteImage noteImage : note.getNoteImages()) {
+            tastingNoteRes.getNoteImages().add(NoteImageRes.from(noteImage));
+        }
+
+        tastingNoteRes.setTastingAt(note.getTastingAt());
+        tastingNoteRes.setMethod(note.getMethod());
+        tastingNoteRes.setPlace(note.getPlace());
+        tastingNoteRes.setScore(note.getScore());
+        tastingNoteRes.setContent(note.getContent());
+        tastingNoteRes.setIsDetail(note.getIsDetail());
+        tastingNoteRes.setNose(note.getNose());
+        tastingNoteRes.setPalate(note.getPalate());
+        tastingNoteRes.setFinish(note.getFinish());
         return tastingNoteRes;
     }
 }

--- a/src/main/java/team_alcoholic/jumo_server/v2/note/dto/response/TastingNoteRes.java
+++ b/src/main/java/team_alcoholic/jumo_server/v2/note/dto/response/TastingNoteRes.java
@@ -1,5 +1,6 @@
 package team_alcoholic.jumo_server.v2.note.dto.response;
 
+import jakarta.persistence.DiscriminatorValue;
 import lombok.Getter;
 import lombok.Setter;
 import team_alcoholic.jumo_server.v1.liquor.dto.LiquorRes;

--- a/src/main/java/team_alcoholic/jumo_server/v2/note/dto/response/TastingNoteRes.java
+++ b/src/main/java/team_alcoholic/jumo_server/v2/note/dto/response/TastingNoteRes.java
@@ -3,11 +3,15 @@ package team_alcoholic.jumo_server.v2.note.dto.response;
 import lombok.Getter;
 import lombok.Setter;
 import team_alcoholic.jumo_server.v1.liquor.dto.LiquorRes;
+import team_alcoholic.jumo_server.v2.aroma.dto.AromaRes;
+import team_alcoholic.jumo_server.v2.note.domain.NoteAroma;
 import team_alcoholic.jumo_server.v2.note.domain.NoteImage;
 import team_alcoholic.jumo_server.v2.note.domain.TastingNote;
 import team_alcoholic.jumo_server.v2.user.dto.UserRes;
 
 import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
 
 @Getter @Setter
 public class TastingNoteRes extends NoteRes{
@@ -15,6 +19,7 @@ public class TastingNoteRes extends NoteRes{
     private LocalDate tastingAt;
     private String method;
     private String place;
+    private List<AromaRes> noteAromas = new ArrayList<>();
     private Integer score;
     private Boolean isDetail;
     private String content;
@@ -24,7 +29,7 @@ public class TastingNoteRes extends NoteRes{
 
     public static TastingNoteRes from(TastingNote note) {
         TastingNoteRes tastingNoteRes = new TastingNoteRes();
-        tastingNoteRes.setId(tastingNoteRes.getId());
+        tastingNoteRes.setId(note.getId());
         tastingNoteRes.setUser(UserRes.from(note.getUser()));
         tastingNoteRes.setLiquor(LiquorRes.from(note.getLiquor()));
         for (NoteImage noteImage : note.getNoteImages()) {
@@ -34,6 +39,9 @@ public class TastingNoteRes extends NoteRes{
         tastingNoteRes.setTastingAt(note.getTastingAt());
         tastingNoteRes.setMethod(note.getMethod());
         tastingNoteRes.setPlace(note.getPlace());
+        for (NoteAroma noteAroma : note.getNoteAromas()) {
+            tastingNoteRes.getNoteAromas().add(AromaRes.from(noteAroma.getAroma()));
+        }
         tastingNoteRes.setScore(note.getScore());
         tastingNoteRes.setContent(note.getContent());
         tastingNoteRes.setIsDetail(note.getIsDetail());

--- a/src/main/java/team_alcoholic/jumo_server/v2/note/exception/NoteNotFoundException.java
+++ b/src/main/java/team_alcoholic/jumo_server/v2/note/exception/NoteNotFoundException.java
@@ -1,0 +1,10 @@
+package team_alcoholic.jumo_server.v2.note.exception;
+
+
+import team_alcoholic.jumo_server.global.error.exception.NotFoundException;
+
+public class NoteNotFoundException extends NotFoundException {
+    public NoteNotFoundException(Long id) {
+        super("해당 id의 Note를 찾지 못함: id " + id);
+    }
+}

--- a/src/main/java/team_alcoholic/jumo_server/v2/note/repository/NoteAromaRepository.java
+++ b/src/main/java/team_alcoholic/jumo_server/v2/note/repository/NoteAromaRepository.java
@@ -1,0 +1,7 @@
+package team_alcoholic.jumo_server.v2.note.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import team_alcoholic.jumo_server.v2.note.domain.NoteAroma;
+
+public interface NoteAromaRepository extends JpaRepository<NoteAroma, Long> {
+}

--- a/src/main/java/team_alcoholic/jumo_server/v2/note/repository/NoteImageRepository.java
+++ b/src/main/java/team_alcoholic/jumo_server/v2/note/repository/NoteImageRepository.java
@@ -1,0 +1,7 @@
+package team_alcoholic.jumo_server.v2.note.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import team_alcoholic.jumo_server.v2.note.domain.NoteImage;
+
+public interface NoteImageRepository extends JpaRepository<NoteImage, Long> {
+}

--- a/src/main/java/team_alcoholic/jumo_server/v2/note/repository/NoteRepository.java
+++ b/src/main/java/team_alcoholic/jumo_server/v2/note/repository/NoteRepository.java
@@ -1,0 +1,13 @@
+package team_alcoholic.jumo_server.v2.note.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import team_alcoholic.jumo_server.v2.note.domain.Note;
+
+import java.util.Optional;
+
+public interface NoteRepository extends JpaRepository<Note, Long> {
+
+    @Query("select n from Note n join fetch n.user join fetch n.liquor join fetch n.noteImages where n.id=:id")
+    Optional<Note> findDetailById(Long id);
+}

--- a/src/main/java/team_alcoholic/jumo_server/v2/note/repository/NoteRepository.java
+++ b/src/main/java/team_alcoholic/jumo_server/v2/note/repository/NoteRepository.java
@@ -1,5 +1,6 @@
 package team_alcoholic.jumo_server.v2.note.repository;
 
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import team_alcoholic.jumo_server.v2.note.domain.Note;
@@ -8,6 +9,11 @@ import java.util.Optional;
 
 public interface NoteRepository extends JpaRepository<Note, Long> {
 
-    @Query("select n from Note n join fetch n.user join fetch n.liquor join fetch n.noteImages where n.id=:id")
+    /**
+     * 노트 상세 조회
+     * @param id 노트 id
+     */
+    @EntityGraph(attributePaths = {"user", "liquor", "noteImages"})
+    @Query("select n from Note n where n.id=:id")
     Optional<Note> findDetailById(Long id);
 }

--- a/src/main/java/team_alcoholic/jumo_server/v2/note/repository/PurchaseNoteRepository.java
+++ b/src/main/java/team_alcoholic/jumo_server/v2/note/repository/PurchaseNoteRepository.java
@@ -1,0 +1,7 @@
+package team_alcoholic.jumo_server.v2.note.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import team_alcoholic.jumo_server.v2.note.domain.PurchaseNote;
+
+public interface PurchaseNoteRepository extends JpaRepository<PurchaseNote, Long> {
+}

--- a/src/main/java/team_alcoholic/jumo_server/v2/note/repository/TastingNoteRepository.java
+++ b/src/main/java/team_alcoholic/jumo_server/v2/note/repository/TastingNoteRepository.java
@@ -1,0 +1,7 @@
+package team_alcoholic.jumo_server.v2.note.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import team_alcoholic.jumo_server.v2.note.domain.TastingNote;
+
+public interface TastingNoteRepository extends JpaRepository<TastingNote, Long> {
+}

--- a/src/main/java/team_alcoholic/jumo_server/v2/note/service/NoteService.java
+++ b/src/main/java/team_alcoholic/jumo_server/v2/note/service/NoteService.java
@@ -2,20 +2,25 @@ package team_alcoholic.jumo_server.v2.note.service;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+import team_alcoholic.jumo_server.global.common.service.CommonUtilService;
 import team_alcoholic.jumo_server.v1.liquor.domain.Liquor;
 import team_alcoholic.jumo_server.v1.liquor.exception.LiquorNotFoundException;
 import team_alcoholic.jumo_server.v1.liquor.repository.LiquorRepository;
+import team_alcoholic.jumo_server.v2.note.domain.NoteImage;
 import team_alcoholic.jumo_server.v2.note.domain.PurchaseNote;
 import team_alcoholic.jumo_server.v2.note.domain.TastingNote;
 import team_alcoholic.jumo_server.v2.note.dto.request.PurchaseNoteCreateReq;
 import team_alcoholic.jumo_server.v2.note.dto.request.TastingNoteCreateReq;
 import team_alcoholic.jumo_server.v2.note.dto.response.PurchaseNoteRes;
 import team_alcoholic.jumo_server.v2.note.dto.response.TastingNoteRes;
+import team_alcoholic.jumo_server.v2.note.repository.NoteImageRepository;
 import team_alcoholic.jumo_server.v2.note.repository.PurchaseNoteRepository;
 import team_alcoholic.jumo_server.v2.note.repository.TastingNoteRepository;
 import team_alcoholic.jumo_server.v2.user.domain.NewUser;
 import team_alcoholic.jumo_server.v2.user.repository.UserRepository;
 
+import java.io.IOException;
 import java.util.UUID;
 
 @Service
@@ -26,22 +31,31 @@ public class NoteService {
     private final TastingNoteRepository tastingNoteRepository;
     private final UserRepository userRepository;
     private final LiquorRepository liquorRepository;
+    private final NoteImageRepository noteImageRepository;
+    private final CommonUtilService commonUtilService;
 
     /**
      * 구매 노트를 생성하는 메서드
      * @param userUuid
      * @param noteCreateReq
      */
-    public PurchaseNoteRes createPurchaseNote(UUID userUuid, PurchaseNoteCreateReq noteCreateReq) {
+    public PurchaseNoteRes createPurchaseNote(UUID userUuid, PurchaseNoteCreateReq noteCreateReq) throws IOException {
         // PurchaseNote 엔티티 생성 및 저장
         NewUser user = userRepository.findByUserUuid(userUuid);
         Liquor liquor = liquorRepository.findById(noteCreateReq.getLiquorId())
             .orElseThrow(() -> new LiquorNotFoundException(noteCreateReq.getLiquorId()));
         PurchaseNote purchaseNote = new PurchaseNote(noteCreateReq, user, liquor);
-        PurchaseNote result = purchaseNoteRepository.save(purchaseNote);
+        purchaseNoteRepository.save(purchaseNote);
+
+        // NoteImage 엔티티 생성 및 저장
+        for (MultipartFile requestImage : noteCreateReq.getNoteImages()) {
+            String imageUrl = commonUtilService.uploadImageToS3(requestImage, "note-image/");
+            NoteImage noteImage = new NoteImage(purchaseNote, requestImage.getOriginalFilename(), imageUrl);
+            noteImageRepository.save(noteImage);
+        }
 
         // dto 변환 후 반환
-        return PurchaseNoteRes.from(result);
+        return PurchaseNoteRes.from(purchaseNote);
     }
 
     /**
@@ -49,13 +63,20 @@ public class NoteService {
      * @param userUuid
      * @param noteCreateReq
      */
-    public TastingNoteRes createTastingNote(UUID userUuid, TastingNoteCreateReq noteCreateReq) {
+    public TastingNoteRes createTastingNote(UUID userUuid, TastingNoteCreateReq noteCreateReq) throws IOException {
         // TastingNote 엔티티 생성 및 저장
         NewUser user = userRepository.findByUserUuid(userUuid);
         Liquor liquor = liquorRepository.findById(noteCreateReq.getLiquorId())
             .orElseThrow(() -> new LiquorNotFoundException(noteCreateReq.getLiquorId()));
         TastingNote tastingNote = new TastingNote(noteCreateReq, user, liquor);
         TastingNote result = tastingNoteRepository.save(tastingNote);
+
+        // NoteImage 엔티티 생성 및 저장
+        for (MultipartFile requestImage : noteCreateReq.getNoteImages()) {
+            String imageUrl = commonUtilService.uploadImageToS3(requestImage, "note-image/");
+            NoteImage noteImage = new NoteImage(tastingNote, requestImage.getOriginalFilename(), imageUrl);
+            noteImageRepository.save(noteImage);
+        }
 
         // dto 변환 후 반환
         return TastingNoteRes.from(result);

--- a/src/main/java/team_alcoholic/jumo_server/v2/note/service/NoteService.java
+++ b/src/main/java/team_alcoholic/jumo_server/v2/note/service/NoteService.java
@@ -1,0 +1,66 @@
+package team_alcoholic.jumo_server.v2.note.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import team_alcoholic.jumo_server.v1.liquor.domain.Liquor;
+import team_alcoholic.jumo_server.v1.liquor.exception.LiquorNotFoundException;
+import team_alcoholic.jumo_server.v1.liquor.repository.LiquorRepository;
+import team_alcoholic.jumo_server.v2.note.domain.PurchaseNote;
+import team_alcoholic.jumo_server.v2.note.domain.TastingNote;
+import team_alcoholic.jumo_server.v2.note.dto.request.PurchaseNoteCreateReq;
+import team_alcoholic.jumo_server.v2.note.dto.request.TastingNoteCreateReq;
+import team_alcoholic.jumo_server.v2.note.dto.response.PurchaseNoteRes;
+import team_alcoholic.jumo_server.v2.note.dto.response.TastingNoteRes;
+import team_alcoholic.jumo_server.v2.note.repository.PurchaseNoteRepository;
+import team_alcoholic.jumo_server.v2.note.repository.TastingNoteRepository;
+import team_alcoholic.jumo_server.v2.user.domain.NewUser;
+import team_alcoholic.jumo_server.v2.user.repository.UserRepository;
+
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class NoteService {
+
+    private final PurchaseNoteRepository purchaseNoteRepository;
+    private final TastingNoteRepository tastingNoteRepository;
+    private final UserRepository userRepository;
+    private final LiquorRepository liquorRepository;
+
+    /**
+     * 구매 노트를 생성하는 메서드
+     * @param userUuid
+     * @param noteCreateReq
+     */
+    public PurchaseNoteRes createPurchaseNote(UUID userUuid, PurchaseNoteCreateReq noteCreateReq) {
+        // PurchaseNote 엔티티 생성 및 저장
+        NewUser user = userRepository.findByUserUuid(userUuid);
+        Liquor liquor = liquorRepository.findById(noteCreateReq.getLiquorId())
+            .orElseThrow(() -> new LiquorNotFoundException(noteCreateReq.getLiquorId()));
+        PurchaseNote purchaseNote = new PurchaseNote(noteCreateReq, user, liquor);
+        PurchaseNote result = purchaseNoteRepository.save(purchaseNote);
+
+        // dto 변환 후 반환
+        return PurchaseNoteRes.from(result);
+    }
+
+    /**
+     * 감상 노트를 생성하는 메서드
+     * @param userUuid
+     * @param noteCreateReq
+     */
+    public TastingNoteRes createTastingNote(UUID userUuid, TastingNoteCreateReq noteCreateReq) {
+        // TastingNote 엔티티 생성 및 저장
+        NewUser user = userRepository.findByUserUuid(userUuid);
+        Liquor liquor = liquorRepository.findById(noteCreateReq.getLiquorId())
+            .orElseThrow(() -> new LiquorNotFoundException(noteCreateReq.getLiquorId()));
+        TastingNote tastingNote = new TastingNote(noteCreateReq, user, liquor);
+        TastingNote result = tastingNoteRepository.save(tastingNote);
+
+        // dto 변환 후 반환
+        TastingNoteRes tastingNoteRes = TastingNoteRes.from(result);
+        System.out.println("Service: " + tastingNoteRes);
+        return tastingNoteRes;
+//        return TastingNoteRes.from(result);
+    }
+}

--- a/src/main/java/team_alcoholic/jumo_server/v2/note/service/NoteService.java
+++ b/src/main/java/team_alcoholic/jumo_server/v2/note/service/NoteService.java
@@ -2,11 +2,15 @@ package team_alcoholic.jumo_server.v2.note.service;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 import team_alcoholic.jumo_server.global.common.service.CommonUtilService;
 import team_alcoholic.jumo_server.v1.liquor.domain.Liquor;
 import team_alcoholic.jumo_server.v1.liquor.exception.LiquorNotFoundException;
 import team_alcoholic.jumo_server.v1.liquor.repository.LiquorRepository;
+import team_alcoholic.jumo_server.v2.aroma.domain.Aroma;
+import team_alcoholic.jumo_server.v2.aroma.repository.AromaRepository;
+import team_alcoholic.jumo_server.v2.note.domain.NoteAroma;
 import team_alcoholic.jumo_server.v2.note.domain.NoteImage;
 import team_alcoholic.jumo_server.v2.note.domain.PurchaseNote;
 import team_alcoholic.jumo_server.v2.note.domain.TastingNote;
@@ -14,6 +18,7 @@ import team_alcoholic.jumo_server.v2.note.dto.request.PurchaseNoteCreateReq;
 import team_alcoholic.jumo_server.v2.note.dto.request.TastingNoteCreateReq;
 import team_alcoholic.jumo_server.v2.note.dto.response.PurchaseNoteRes;
 import team_alcoholic.jumo_server.v2.note.dto.response.TastingNoteRes;
+import team_alcoholic.jumo_server.v2.note.repository.NoteAromaRepository;
 import team_alcoholic.jumo_server.v2.note.repository.NoteImageRepository;
 import team_alcoholic.jumo_server.v2.note.repository.PurchaseNoteRepository;
 import team_alcoholic.jumo_server.v2.note.repository.TastingNoteRepository;
@@ -21,6 +26,7 @@ import team_alcoholic.jumo_server.v2.user.domain.NewUser;
 import team_alcoholic.jumo_server.v2.user.repository.UserRepository;
 
 import java.io.IOException;
+import java.util.List;
 import java.util.UUID;
 
 @Service
@@ -31,14 +37,17 @@ public class NoteService {
     private final TastingNoteRepository tastingNoteRepository;
     private final UserRepository userRepository;
     private final LiquorRepository liquorRepository;
+    private final AromaRepository aromaRepository;
     private final NoteImageRepository noteImageRepository;
+    private final NoteAromaRepository noteAromaRepository;
     private final CommonUtilService commonUtilService;
 
     /**
      * 구매 노트를 생성하는 메서드
-     * @param userUuid
-     * @param noteCreateReq
+     * @param userUuid 사용자의 uuid
+     * @param noteCreateReq 구매 노트 생성 API 요청 객체
      */
+    @Transactional
     public PurchaseNoteRes createPurchaseNote(UUID userUuid, PurchaseNoteCreateReq noteCreateReq) throws IOException {
         // PurchaseNote 엔티티 생성 및 저장
         NewUser user = userRepository.findByUserUuid(userUuid);
@@ -60,16 +69,17 @@ public class NoteService {
 
     /**
      * 감상 노트를 생성하는 메서드
-     * @param userUuid
-     * @param noteCreateReq
+     * @param userUuid 사용자의 uuid
+     * @param noteCreateReq 감상 노트 생성 API 요청 객체
      */
+    @Transactional
     public TastingNoteRes createTastingNote(UUID userUuid, TastingNoteCreateReq noteCreateReq) throws IOException {
         // TastingNote 엔티티 생성 및 저장
         NewUser user = userRepository.findByUserUuid(userUuid);
         Liquor liquor = liquorRepository.findById(noteCreateReq.getLiquorId())
             .orElseThrow(() -> new LiquorNotFoundException(noteCreateReq.getLiquorId()));
         TastingNote tastingNote = new TastingNote(noteCreateReq, user, liquor);
-        TastingNote result = tastingNoteRepository.save(tastingNote);
+        tastingNoteRepository.save(tastingNote);
 
         // NoteImage 엔티티 생성 및 저장
         for (MultipartFile requestImage : noteCreateReq.getNoteImages()) {
@@ -78,7 +88,14 @@ public class NoteService {
             noteImageRepository.save(noteImage);
         }
 
+        // NoteAroma 엔티티 생성 및 저장
+        List<Aroma> requestAromas = aromaRepository.findAllById(noteCreateReq.getNoteAromas());
+        for (Aroma requestAroma : requestAromas) {
+            NoteAroma noteAroma = new NoteAroma(tastingNote, requestAroma);
+            noteAromaRepository.save(noteAroma);
+        }
+
         // dto 변환 후 반환
-        return TastingNoteRes.from(result);
+        return TastingNoteRes.from(tastingNote);
     }
 }

--- a/src/main/java/team_alcoholic/jumo_server/v2/note/service/NoteService.java
+++ b/src/main/java/team_alcoholic/jumo_server/v2/note/service/NoteService.java
@@ -10,18 +10,14 @@ import team_alcoholic.jumo_server.v1.liquor.exception.LiquorNotFoundException;
 import team_alcoholic.jumo_server.v1.liquor.repository.LiquorRepository;
 import team_alcoholic.jumo_server.v2.aroma.domain.Aroma;
 import team_alcoholic.jumo_server.v2.aroma.repository.AromaRepository;
-import team_alcoholic.jumo_server.v2.note.domain.NoteAroma;
-import team_alcoholic.jumo_server.v2.note.domain.NoteImage;
-import team_alcoholic.jumo_server.v2.note.domain.PurchaseNote;
-import team_alcoholic.jumo_server.v2.note.domain.TastingNote;
+import team_alcoholic.jumo_server.v2.note.domain.*;
 import team_alcoholic.jumo_server.v2.note.dto.request.PurchaseNoteCreateReq;
 import team_alcoholic.jumo_server.v2.note.dto.request.TastingNoteCreateReq;
+import team_alcoholic.jumo_server.v2.note.dto.response.GeneralNoteRes;
 import team_alcoholic.jumo_server.v2.note.dto.response.PurchaseNoteRes;
 import team_alcoholic.jumo_server.v2.note.dto.response.TastingNoteRes;
-import team_alcoholic.jumo_server.v2.note.repository.NoteAromaRepository;
-import team_alcoholic.jumo_server.v2.note.repository.NoteImageRepository;
-import team_alcoholic.jumo_server.v2.note.repository.PurchaseNoteRepository;
-import team_alcoholic.jumo_server.v2.note.repository.TastingNoteRepository;
+import team_alcoholic.jumo_server.v2.note.exception.NoteNotFoundException;
+import team_alcoholic.jumo_server.v2.note.repository.*;
 import team_alcoholic.jumo_server.v2.user.domain.NewUser;
 import team_alcoholic.jumo_server.v2.user.repository.UserRepository;
 
@@ -33,6 +29,7 @@ import java.util.UUID;
 @RequiredArgsConstructor
 public class NoteService {
 
+    private final NoteRepository noterepository;
     private final PurchaseNoteRepository purchaseNoteRepository;
     private final TastingNoteRepository tastingNoteRepository;
     private final UserRepository userRepository;
@@ -97,5 +94,15 @@ public class NoteService {
 
         // dto 변환 후 반환
         return TastingNoteRes.from(tastingNote);
+    }
+
+    /**
+     * id에 해당하는 노트를 조회하는 메서드
+     * @param id 조회하려는 노트의 id
+     */
+    public GeneralNoteRes getNoteById(Long id) {
+        Note note = noterepository.findDetailById(id)
+            .orElseThrow(() -> new NoteNotFoundException(id));
+        return GeneralNoteRes.from(note);
     }
 }

--- a/src/main/java/team_alcoholic/jumo_server/v2/note/service/NoteService.java
+++ b/src/main/java/team_alcoholic/jumo_server/v2/note/service/NoteService.java
@@ -58,9 +58,6 @@ public class NoteService {
         TastingNote result = tastingNoteRepository.save(tastingNote);
 
         // dto 변환 후 반환
-        TastingNoteRes tastingNoteRes = TastingNoteRes.from(result);
-        System.out.println("Service: " + tastingNoteRes);
-        return tastingNoteRes;
-//        return TastingNoteRes.from(result);
+        return TastingNoteRes.from(result);
     }
 }

--- a/src/main/java/team_alcoholic/jumo_server/v2/note/service/NoteService.java
+++ b/src/main/java/team_alcoholic/jumo_server/v2/note/service/NoteService.java
@@ -29,7 +29,7 @@ import java.util.UUID;
 @RequiredArgsConstructor
 public class NoteService {
 
-    private final NoteRepository noterepository;
+    private final NoteRepository noteRepository;
     private final PurchaseNoteRepository purchaseNoteRepository;
     private final TastingNoteRepository tastingNoteRepository;
     private final UserRepository userRepository;
@@ -100,8 +100,9 @@ public class NoteService {
      * id에 해당하는 노트를 조회하는 메서드
      * @param id 조회하려는 노트의 id
      */
+    @Transactional
     public GeneralNoteRes getNoteById(Long id) {
-        Note note = noterepository.findDetailById(id)
+        Note note = noteRepository.findDetailById(id)
             .orElseThrow(() -> new NoteNotFoundException(id));
         return GeneralNoteRes.from(note);
     }

--- a/src/main/java/team_alcoholic/jumo_server/v2/user/controller/UserController.java
+++ b/src/main/java/team_alcoholic/jumo_server/v2/user/controller/UserController.java
@@ -69,7 +69,7 @@ public class UserController {
     @PutMapping
     public UserRes updateUser(
         @AuthenticationPrincipal OAuth2User oAuth2User,
-        @ModelAttribute  UserUpdateReq userUpdateReq,
+        @ModelAttribute UserUpdateReq userUpdateReq,
         HttpSession session
     ) throws IOException {
         if (oAuth2User == null) { throw new UnauthorizedException("로그인이 필요합니다."); }

--- a/src/main/java/team_alcoholic/jumo_server/v2/user/dto/UserRes.java
+++ b/src/main/java/team_alcoholic/jumo_server/v2/user/dto/UserRes.java
@@ -3,7 +3,6 @@ package team_alcoholic.jumo_server.v2.user.dto;
 
 import lombok.Builder;
 import org.springframework.security.oauth2.core.user.OAuth2User;
-import team_alcoholic.jumo_server.v1.user.domain.User;
 import team_alcoholic.jumo_server.v2.user.domain.NewUser;
 
 import java.util.UUID;
@@ -24,7 +23,7 @@ public record UserRes(
     public UserRes {
     }
 
-    public static UserRes fromEntity(NewUser user) {
+    public static UserRes from(NewUser user) {
         return UserRes.builder()
             .profileNickname(user.getNickname())
             .profileThumbnailImage(user.getThumbnailImage())

--- a/src/main/java/team_alcoholic/jumo_server/v2/user/service/UserService.java
+++ b/src/main/java/team_alcoholic/jumo_server/v2/user/service/UserService.java
@@ -124,7 +124,7 @@ public class UserService {
         // 세션 갱신
         updateUserSession(session, user);
 
-        return UserRes.fromEntity(user);
+        return UserRes.from(user);
     }
 
     /**

--- a/src/main/resources/application-local.properties
+++ b/src/main/resources/application-local.properties
@@ -33,7 +33,7 @@ spring.datasource.password=${DB_PASSWORD}
 spring.datasource.driver-class-name=${DB_DRIVER}
 
 # Hibernate settings
-spring.jpa.hibernate.ddl-auto=none
+spring.jpa.hibernate.ddl-auto=update
 spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQLDialect
 


### PR DESCRIPTION
## 🚀 Jira 티켓
**[BYOB-220]**

<br>

## 🔨 작업 사항 

Note 도메인 API 중 일부 구현함: 노트 작성 API, 노트 상세조회 API

### 1. Note 도메인 dto 구현
1. `PurchaseNoteCreateReq`, `TastingNoteCreateReq`: 각각 구매 노트, 감상 노트 작성 API에 대한 요청 dto
2. `PurchaseNoteRes`, `TastingNoteRes`, `NoteRes`: 각각 구매 노트, 감상 노트 응답 dto와 공통 필드에 대한 추상 클래스
3. `GeneralNoteRes`: 상속 엔티티 구조의 PurchaseNoteRes와 TastingNoteRes를 함께 응답하기 위한 dto
```java
public class GeneralNoteRes {
    private String type;
    private PurchaseNoteRes purchaseNote;
    private TastingNoteRes tastingNote;
    ...
}
```

### 2. 노트 작성 API
구매 노트 작성 API, 감상 노트 작성 API를 각각 구현함.
- `POST /notes/purchase`
- `POST /notes/tasting`

### 3. 노트 상세조회 API
노트 상세조회 API를 구현함.
- `GET /notes/{id}`

부모 엔티티를 조회할 경우, 내부적으로 자식 엔티티들에 대해 자동으로 join이 발생하게 됨. 결과적으로 조회 결과들은 해당하는 자식 엔티티 타입을 갖지만, 부모 엔티티 타입으로 업캐스팅되기 때문에 부모 엔티티 타입을 갖는 동일한 컬렉션에 함께 담겨 반환될 수 있음.
따라서 응답 시에는 각 요소에 대해 `instance of` 연산을 수행하여 실제 타입을 판별해 다운캐스팅해주는 로직을 구현함.
```java
public class GeneralNoteRes {
    ...
    public static GeneralNoteRes from(Note note) {
        GeneralNoteRes noteRes = new GeneralNoteRes();
        if (note instanceof PurchaseNote purchaseNote) {
            noteRes.setType(purchaseNote.getClass().getAnnotation(DiscriminatorValue.class).value());
            noteRes.setPurchaseNote(PurchaseNoteRes.from(purchaseNote));
        }
        else if (note instanceof TastingNote tastingNote) {
            noteRes.setType(tastingNote.getClass().getAnnotation(DiscriminatorValue.class).value());
            noteRes.setTastingNote(TastingNoteRes.from(tastingNote));
        }
        return noteRes;
    }
    ...
}
```

### 개선사항
1. 상속 엔티티 구조에서의 N+1 문제
: 부모 엔티티인 `Note`에 대한 자식 엔티티들 중 `TastingNote`에만 존재하는 연관 엔티티인 `NoteAroma`에 대해서는 `Note` 타입에서 fetch join을 수행할 수 없는 문제가 있음. 때문에 조회 시 N+1 문제 발생

2. `TastingNoteRes.from()` 메서드에서의 N+1 문제
: `TastingNoteRes`의 `from` 메서드 내에서, 인자로 받은 `TastingNote` 엔티티의 `getNoteAromas()`를 호출할 때 `NoteAroma`에 대한 지연 로딩이 발생하고, 각각의 `NoteAroma`를 순회하면서 `getAroma()`를 호출할 때 다시 `Aroma`에 대한 지연 로딩이 발생함.


[BYOB-220]: https://swm-alcoholic.atlassian.net/browse/BYOB-220?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
	- 이미지 파일을 Amazon S3 버킷에 업로드하는 기능 추가.
	- 구매 및 테이스팅 노트를 관리하는 새로운 REST 컨트롤러 추가.
	- 구매 및 테이스팅 노트를 생성하고 ID로 노트를 검색하는 서비스 추가.

- **버그 수정**
	- DTO 변경으로 인한 메소드 반환 및 파라미터 수정.

- **문서화**
	- 새로운 클래스 및 메소드에 대한 설명 추가.

- **리팩토링**
	- DTO 이름 변경 및 관련 메소드 업데이트.

- **스타일**
	- 코드 포맷 일관성 유지.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->