### PR TITLE
[BYOB-221] Note 도메인 API 구현: 노트 페이지네이션 조회 및 수정 API

### DIFF
--- a/src/main/java/team_alcoholic/jumo_server/v1/liquor/domain/Liquor.java
+++ b/src/main/java/team_alcoholic/jumo_server/v1/liquor/domain/Liquor.java
@@ -6,7 +6,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import team_alcoholic.jumo_server.v1.tastingnote.domain.AiTastingNote;
-import team_alcoholic.jumo_server.v1.tastingnote.domain.TastingNote;
+import team_alcoholic.jumo_server.v1.tastingnote.domain.TastingNoteV1;
 import team_alcoholic.jumo_server.v1.user.domain.User;
 import team_alcoholic.jumo_server.global.common.domain.BaseEntity;
 
@@ -48,6 +48,6 @@ public class Liquor extends BaseEntity {
 
 
     @OneToMany(mappedBy = "liquor", fetch = FetchType.LAZY)
-    private List<TastingNote> tastingNotes;
+    private List<TastingNoteV1> tastingNotes;
 
 }

--- a/src/main/java/team_alcoholic/jumo_server/v1/tastingnote/domain/TastingNoteV1.java
+++ b/src/main/java/team_alcoholic/jumo_server/v1/tastingnote/domain/TastingNoteV1.java
@@ -11,7 +11,7 @@ import team_alcoholic.jumo_server.global.common.domain.BaseEntity;
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor
-public class TastingNote extends BaseEntity {
+public class TastingNoteV1 extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/team_alcoholic/jumo_server/v1/tastingnote/dto/TastingNoteResDTO.java
+++ b/src/main/java/team_alcoholic/jumo_server/v1/tastingnote/dto/TastingNoteResDTO.java
@@ -2,7 +2,7 @@ package team_alcoholic.jumo_server.v1.tastingnote.dto;
 
 import lombok.Builder;
 import team_alcoholic.jumo_server.v1.liquor.dto.LiquorRes;
-import team_alcoholic.jumo_server.v1.tastingnote.domain.TastingNote;
+import team_alcoholic.jumo_server.v1.tastingnote.domain.TastingNoteV1;
 import team_alcoholic.jumo_server.v1.user.dto.UserRes;
 
 public record TastingNoteResDTO(
@@ -28,7 +28,7 @@ public record TastingNoteResDTO(
     public TastingNoteResDTO {
     }
 
-    public static TastingNoteResDTO fromEntity(TastingNote tastingNote) {
+    public static TastingNoteResDTO fromEntity(TastingNoteV1 tastingNote) {
         return TastingNoteResDTO.builder()
                 .id(tastingNote.getId())
                 .liquor(LiquorRes.from(tastingNote.getLiquor()))

--- a/src/main/java/team_alcoholic/jumo_server/v1/tastingnote/repository/TastingNoteRepositoryV1.java
+++ b/src/main/java/team_alcoholic/jumo_server/v1/tastingnote/repository/TastingNoteRepositoryV1.java
@@ -4,18 +4,18 @@ import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
-import team_alcoholic.jumo_server.v1.tastingnote.domain.TastingNote;
+import team_alcoholic.jumo_server.v1.tastingnote.domain.TastingNoteV1;
 
 import java.util.List;
 import java.util.UUID;
 
-public interface TastingNoteRepositoryV1 extends JpaRepository<TastingNote, Long> {
+public interface TastingNoteRepositoryV1 extends JpaRepository<TastingNoteV1, Long> {
 
-    @Query("SELECT tn FROM TastingNote tn WHERE tn.liquor.id = :liquorId ORDER BY tn.createdAt DESC")
+    @Query("SELECT tn FROM TastingNoteV1 tn WHERE tn.liquor.id = :liquorId ORDER BY tn.createdAt DESC")
     @EntityGraph(attributePaths = {"liquor", "user"})
-    List<TastingNote> findTastingNotesByLiquorId(@Param("liquorId") Long liquorId);
+    List<TastingNoteV1> findTastingNotesByLiquorId(@Param("liquorId") Long liquorId);
 
-    @Query("SELECT tn FROM TastingNote tn WHERE tn.user.userUuid = :userUuid ORDER BY tn.createdAt DESC")
+    @Query("SELECT tn FROM TastingNoteV1 tn WHERE tn.user.userUuid = :userUuid ORDER BY tn.createdAt DESC")
     @EntityGraph(attributePaths = {"liquor", "user"})
-    List<TastingNote> findTastingNotesByUserUuId(@Param("userUuid") UUID userUuid);
+    List<TastingNoteV1> findTastingNotesByUserUuId(@Param("userUuid") UUID userUuid);
 }

--- a/src/main/java/team_alcoholic/jumo_server/v1/tastingnote/service/TastingNoteService.java
+++ b/src/main/java/team_alcoholic/jumo_server/v1/tastingnote/service/TastingNoteService.java
@@ -10,7 +10,7 @@ import team_alcoholic.jumo_server.v1.liquor.domain.Liquor;
 import team_alcoholic.jumo_server.v1.liquor.exception.LiquorNotFoundException;
 import team_alcoholic.jumo_server.v1.liquor.repository.LiquorRepository;
 import team_alcoholic.jumo_server.v1.tastingnote.domain.AiTastingNote;
-import team_alcoholic.jumo_server.v1.tastingnote.domain.TastingNote;
+import team_alcoholic.jumo_server.v1.tastingnote.domain.TastingNoteV1;
 import team_alcoholic.jumo_server.v1.tastingnote.dto.*;
 import team_alcoholic.jumo_server.v1.tastingnote.exception.TastingNoteNotFoundException;
 import team_alcoholic.jumo_server.v1.tastingnote.repository.AiTastingNoteRepository;
@@ -52,13 +52,13 @@ public class TastingNoteService {
 
         Liquor liquor = liquorRepository.findById(saveTastingNoteReqDTO.getLiquorId())
                 .orElseThrow(() -> new LiquorNotFoundException(saveTastingNoteReqDTO.getLiquorId()));
-        TastingNote newTastingNote = convertToEntity(saveTastingNoteReqDTO, liquor, user);
+        TastingNoteV1 newTastingNote = convertToEntity(saveTastingNoteReqDTO, liquor, user);
 
         return tastingNoteRepositoryV1.save(newTastingNote).getId();
     }
 
-    private TastingNote convertToEntity(SaveTastingNoteReqDTO dto, Liquor liquor, User user) {
-        return TastingNote.builder()
+    private TastingNoteV1 convertToEntity(SaveTastingNoteReqDTO dto, Liquor liquor, User user) {
+        return TastingNoteV1.builder()
                 .user(user)
                 .liquor(liquor)
                 .noseScore(dto.getNoseScore())
@@ -76,7 +76,7 @@ public class TastingNoteService {
     }
 
     public TastingNoteResDTO getTastingNoteById(Long id) {
-        TastingNote tastingNote = tastingNoteRepositoryV1.findById(id)
+        TastingNoteV1 tastingNote = tastingNoteRepositoryV1.findById(id)
                 .orElseThrow(() -> new TastingNoteNotFoundException(id));
 
         return TastingNoteResDTO.fromEntity(tastingNote);
@@ -86,7 +86,7 @@ public class TastingNoteService {
      * Liquor id에 해당하는 테이스팅 노트 목록을 반환
      */
     public List<TastingNoteResDTO> getTastingNoteListByLiquor(Long liquor) {
-        List<TastingNote> result = tastingNoteRepositoryV1.findTastingNotesByLiquorId(liquor);
+        List<TastingNoteV1> result = tastingNoteRepositoryV1.findTastingNotesByLiquorId(liquor);
         return result.stream().map(TastingNoteResDTO::fromEntity).collect(Collectors.toList());
     }
 
@@ -95,7 +95,7 @@ public class TastingNoteService {
      */
     public List<TastingNoteResDTO> getTastingNoteListByUser(String userUuid) {
         UUID uuid = UUID.fromString(userUuid);
-        List<TastingNote> result = tastingNoteRepositoryV1.findTastingNotesByUserUuId(uuid);
+        List<TastingNoteV1> result = tastingNoteRepositoryV1.findTastingNotesByUserUuId(uuid);
         return result.stream().map(TastingNoteResDTO::fromEntity).collect(Collectors.toList());
     }
 
@@ -114,7 +114,7 @@ public class TastingNoteService {
 
     @Transactional
     public Long updateTastingNote(Long id, UpdateTastingNoteReqDTO updateTastingNoteReqDTO, User user) throws AccessDeniedException {
-        TastingNote tastingNote = tastingNoteRepositoryV1.findById(id)
+        TastingNoteV1 tastingNote = tastingNoteRepositoryV1.findById(id)
                 .orElseThrow(() -> new TastingNoteNotFoundException(id));
 
         if (!tastingNote.getUser().getId().equals(user.getId())) {

--- a/src/main/java/team_alcoholic/jumo_server/v2/note/controller/NoteController.java
+++ b/src/main/java/team_alcoholic/jumo_server/v2/note/controller/NoteController.java
@@ -8,7 +8,7 @@ import team_alcoholic.jumo_server.global.error.exception.UnauthorizedException;
 import team_alcoholic.jumo_server.v2.note.dto.request.PurchaseNoteCreateReq;
 import team_alcoholic.jumo_server.v2.note.dto.request.TastingNoteCreateReq;
 import team_alcoholic.jumo_server.v2.note.dto.response.GeneralNoteRes;
-import team_alcoholic.jumo_server.v2.note.dto.response.NoteRes;
+import team_alcoholic.jumo_server.v2.note.dto.response.NoteListRes;
 import team_alcoholic.jumo_server.v2.note.dto.response.PurchaseNoteRes;
 import team_alcoholic.jumo_server.v2.note.dto.response.TastingNoteRes;
 import team_alcoholic.jumo_server.v2.note.service.NoteService;
@@ -57,5 +57,44 @@ public class NoteController {
     @GetMapping("/{id}")
     public GeneralNoteRes getNoteById(@PathVariable Long id) {
         return noteService.getNoteById(id);
+    }
+
+    /**
+     * 전체 노트 목록 페이지네이션 조회 API
+     * @param cursor 마지막으로 조회한 노트 id
+     * @param limit 최대 조회 목록 크기
+     */
+    @GetMapping
+    public NoteListRes getNotesById(
+        @RequestParam(required = false) Long cursor,
+        @RequestParam int limit
+    ) {
+        return noteService.getNotesById(cursor, limit, "ALL");
+    }
+
+    /**
+     * 구매 노트 목록 페이지네이션 조회 API
+     * @param cursor 마지막으로 조회한 노트 id
+     * @param limit 최대 조회 목록 크기
+     */
+    @GetMapping("/purchase")
+    public NoteListRes getPurchaseNotesById(
+        @RequestParam(required = false) Long cursor,
+        @RequestParam int limit
+    ) {
+        return noteService.getNotesById(cursor, limit, "PURCHASE");
+    }
+
+    /**
+     * 감상 노트 목록 페이지네이션 조회 API
+     * @param cursor 마지막으로 조회한 노트 id
+     * @param limit 최대 조회 목록 크기
+     */
+    @GetMapping("/tasting")
+    public NoteListRes getTastingNotesById(
+        @RequestParam(required = false) Long cursor,
+        @RequestParam int limit
+    ) {
+        return noteService.getNotesById(cursor, limit, "TASTING");
     }
 }

--- a/src/main/java/team_alcoholic/jumo_server/v2/note/controller/NoteController.java
+++ b/src/main/java/team_alcoholic/jumo_server/v2/note/controller/NoteController.java
@@ -135,11 +135,11 @@ public class NoteController {
 
     /**
      * 사용자가 작성한 노트 목록 조회 API
-     * @param oAuth2User 세션에서 조회하는 user 정보
+     * @param userUuid 사용자 uuid
      */
-    @GetMapping("/user")
-    public List<GeneralNoteRes> getNotesByUser(@AuthenticationPrincipal OAuth2User oAuth2User) {
-        return noteService.getNotesByUser(oAuth2User.getAttribute("userUuid"));
+    @GetMapping("/user/{userUuid}")
+    public List<GeneralNoteRes> getNotesByUser(@PathVariable UUID userUuid) {
+        return noteService.getNotesByUser(userUuid);
     }
 
     /**

--- a/src/main/java/team_alcoholic/jumo_server/v2/note/controller/NoteController.java
+++ b/src/main/java/team_alcoholic/jumo_server/v2/note/controller/NoteController.java
@@ -1,6 +1,7 @@
 package team_alcoholic.jumo_server.v2.note.controller;
 
 import lombok.RequiredArgsConstructor;
+import org.aspectj.weaver.ast.Not;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.web.bind.annotation.*;
@@ -14,6 +15,8 @@ import team_alcoholic.jumo_server.v2.note.dto.response.TastingNoteRes;
 import team_alcoholic.jumo_server.v2.note.service.NoteService;
 
 import java.io.IOException;
+import java.util.List;
+import java.util.UUID;
 
 @RestController
 @RequestMapping("v2/notes")
@@ -60,7 +63,7 @@ public class NoteController {
     }
 
     /**
-     * 전체 노트 목록 페이지네이션 조회 API
+     * 서비스 전체 노트 목록 페이지네이션 조회 API
      * @param cursor 마지막으로 조회한 노트 id
      * @param limit 최대 조회 목록 크기
      */
@@ -73,9 +76,9 @@ public class NoteController {
     }
 
     /**
-     * 구매 노트 목록 페이지네이션 조회 API
+     * 서비스 전체 구매 노트 목록 페이지네이션 조회 API
      * @param cursor 마지막으로 조회한 노트 id
-     * @param limit 최대 조회 목록 크기
+     * @param limit 최대 페이지 크기
      */
     @GetMapping("/purchase")
     public NoteListRes getPurchaseNotesById(
@@ -86,9 +89,9 @@ public class NoteController {
     }
 
     /**
-     * 감상 노트 목록 페이지네이션 조회 API
+     * 서비스 전체 감상 노트 목록 페이지네이션 조회 API
      * @param cursor 마지막으로 조회한 노트 id
-     * @param limit 최대 조회 목록 크기
+     * @param limit 최대 페이지 크기
      */
     @GetMapping("/tasting")
     public NoteListRes getTastingNotesById(
@@ -96,5 +99,23 @@ public class NoteController {
         @RequestParam int limit
     ) {
         return noteService.getNotesById(cursor, limit, "TASTING");
+    }
+
+    /**
+     * 사용자가 작성한 노트 목록 조회 API
+     * @param userUuid 사용자 uuid
+     */
+    @GetMapping("/user/{userUuid}")
+    public List<GeneralNoteRes> getNotesByUser(@PathVariable UUID userUuid) {
+        return noteService.getNotesByUser(userUuid);
+    }
+
+    /**
+     * 주류에 작성된 노트 목록 조회 API
+     * @param liquorId 주류 id
+     */
+    @GetMapping("/liquor/{liquorId}")
+    public List<GeneralNoteRes> getNotesByLiquor(@PathVariable Long liquorId) {
+        return noteService.getNotesByLiquor(liquorId);
     }
 }

--- a/src/main/java/team_alcoholic/jumo_server/v2/note/controller/NoteController.java
+++ b/src/main/java/team_alcoholic/jumo_server/v2/note/controller/NoteController.java
@@ -7,7 +7,9 @@ import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.web.bind.annotation.*;
 import team_alcoholic.jumo_server.global.error.exception.UnauthorizedException;
 import team_alcoholic.jumo_server.v2.note.dto.request.PurchaseNoteCreateReq;
+import team_alcoholic.jumo_server.v2.note.dto.request.PurchaseNoteUpdateReq;
 import team_alcoholic.jumo_server.v2.note.dto.request.TastingNoteCreateReq;
+import team_alcoholic.jumo_server.v2.note.dto.request.TastingNoteUpdateReq;
 import team_alcoholic.jumo_server.v2.note.dto.response.GeneralNoteRes;
 import team_alcoholic.jumo_server.v2.note.dto.response.NoteListRes;
 import team_alcoholic.jumo_server.v2.note.dto.response.PurchaseNoteRes;
@@ -27,8 +29,8 @@ public class NoteController {
 
     /**
      * 구매 노트 생성 API
-     * @param oAuth2User
-     * @param noteCreateReq
+     * @param oAuth2User 세션에서 조회하는 user 정보
+     * @param noteCreateReq 구매 노트 생성 요청 객체
      */
     @PostMapping("/purchase")
     public PurchaseNoteRes createPurchaseNote(
@@ -41,8 +43,8 @@ public class NoteController {
 
     /**
      * 감상 노트 생성 API
-     * @param oAuth2User
-     * @param noteCreateReq
+     * @param oAuth2User 세션에서 조회하는 user 정보
+     * @param noteCreateReq 감상 노트 생성 요청 객체
      */
     @PostMapping("/tasting")
     public TastingNoteRes createTastingNote(
@@ -51,6 +53,36 @@ public class NoteController {
     ) throws IOException {
         if (oAuth2User == null) { throw new UnauthorizedException("로그인이 필요합니다."); }
         return noteService.createTastingNote(oAuth2User.getAttribute("userUuid"), noteCreateReq);
+    }
+
+    /**
+     * 구매 노트 수정 API
+     * @param oAuth2User 세션에서 조회하는 user 정보
+     * @param noteId 수정하려는 노트 id
+     * @param noteUpdateReq 구매 노트 수정 요청 객체
+     */
+    @PutMapping("/purchase/{noteId}")
+    public PurchaseNoteRes updatePurchaseNote(
+        @AuthenticationPrincipal OAuth2User oAuth2User,
+        @PathVariable Long noteId,
+        @ModelAttribute PurchaseNoteUpdateReq noteUpdateReq
+    ) throws IOException {
+        return noteService.updatePurchaseNote(oAuth2User, noteId, noteUpdateReq);
+    }
+
+    /**
+     * 감상 노트 수정 API
+     * @param oAuth2User 세션에서 조회하는 user 정보
+     * @param noteId 수정하려는 노트 id
+     * @param noteUpdateReq 감상 노트 수정 요청 객체
+     */
+    @PutMapping("/tasting/{noteId}")
+    public TastingNoteRes updateTastingNote(
+        @AuthenticationPrincipal OAuth2User oAuth2User,
+        @PathVariable Long noteId,
+        @ModelAttribute TastingNoteUpdateReq noteUpdateReq
+    ) throws IOException {
+        return noteService.updateTastingNote(oAuth2User, noteId, noteUpdateReq);
     }
 
     /**

--- a/src/main/java/team_alcoholic/jumo_server/v2/note/controller/NoteController.java
+++ b/src/main/java/team_alcoholic/jumo_server/v2/note/controller/NoteController.java
@@ -135,11 +135,11 @@ public class NoteController {
 
     /**
      * 사용자가 작성한 노트 목록 조회 API
-     * @param userUuid 사용자 uuid
+     * @param oAuth2User 세션에서 조회하는 user 정보
      */
-    @GetMapping("/user/{userUuid}")
-    public List<GeneralNoteRes> getNotesByUser(@PathVariable UUID userUuid) {
-        return noteService.getNotesByUser(userUuid);
+    @GetMapping("/user")
+    public List<GeneralNoteRes> getNotesByUser(@AuthenticationPrincipal OAuth2User oAuth2User) {
+        return noteService.getNotesByUser(oAuth2User.getAttribute("userUuid"));
     }
 
     /**

--- a/src/main/java/team_alcoholic/jumo_server/v2/note/domain/PurchaseNote.java
+++ b/src/main/java/team_alcoholic/jumo_server/v2/note/domain/PurchaseNote.java
@@ -5,6 +5,7 @@ import jakarta.persistence.Entity;
 import lombok.Getter;
 import team_alcoholic.jumo_server.v1.liquor.domain.Liquor;
 import team_alcoholic.jumo_server.v2.note.dto.request.PurchaseNoteCreateReq;
+import team_alcoholic.jumo_server.v2.note.dto.request.PurchaseNoteUpdateReq;
 import team_alcoholic.jumo_server.v2.user.domain.NewUser;
 
 import java.time.LocalDate;
@@ -28,5 +29,13 @@ public class PurchaseNote extends Note {
         this.price = noteCreateReq.getPrice();
         this.volume = noteCreateReq.getVolume();
         this.content = noteCreateReq.getContent();
+    }
+
+    public void update(PurchaseNoteUpdateReq noteUpdateReq) {
+        if (noteUpdateReq.getPurchaseAt() != null) { this.purchaseAt = noteUpdateReq.getPurchaseAt(); }
+        if (noteUpdateReq.getPlace() != null) { this.place = noteUpdateReq.getPlace(); }
+        if (noteUpdateReq.getPrice() != null) { this.price = noteUpdateReq.getPrice(); }
+        if (noteUpdateReq.getVolume() != null) { this.volume = noteUpdateReq.getVolume(); }
+        if (noteUpdateReq.getContent() != null) { this.content = noteUpdateReq.getContent(); }
     }
 }

--- a/src/main/java/team_alcoholic/jumo_server/v2/note/domain/TastingNote.java
+++ b/src/main/java/team_alcoholic/jumo_server/v2/note/domain/TastingNote.java
@@ -7,6 +7,7 @@ import jakarta.persistence.OneToMany;
 import lombok.Getter;
 import team_alcoholic.jumo_server.v1.liquor.domain.Liquor;
 import team_alcoholic.jumo_server.v2.note.dto.request.TastingNoteCreateReq;
+import team_alcoholic.jumo_server.v2.note.dto.request.TastingNoteUpdateReq;
 import team_alcoholic.jumo_server.v2.user.domain.NewUser;
 
 import java.time.LocalDate;
@@ -43,5 +44,29 @@ public class TastingNote extends Note {
         this.nose = noteCreateReq.getNose();
         this.palate = noteCreateReq.getPalate();
         this.finish = noteCreateReq.getFinish();
+    }
+
+    public void update(TastingNoteUpdateReq noteUpdateReq) {
+        if (noteUpdateReq.getTastingAt() != null) { this.tastingAt = noteUpdateReq.getTastingAt(); }
+        if (noteUpdateReq.getMethod() != null) { this.method = noteUpdateReq.getMethod(); }
+        if (noteUpdateReq.getPlace() != null) { this.place = noteUpdateReq.getPlace(); }
+        if (noteUpdateReq.getScore() != null) { this.score = noteUpdateReq.getScore(); }
+        if (noteUpdateReq.getContent() != null) { this.content = noteUpdateReq.getContent(); }
+
+        // 상세작성 활성화된 경우
+        if (noteUpdateReq.getIsDetail() != null && noteUpdateReq.getIsDetail()) {
+            this.isDetail = true;
+            this.nose = noteUpdateReq.getNose();
+            this.palate = noteUpdateReq.getPalate();
+            this.finish = noteUpdateReq.getFinish();
+        }
+        // 상세작성 비활성화된 경우
+        if (noteUpdateReq.getIsDetail() != null && !noteUpdateReq.getIsDetail()) { this.isDetail = false; }
+        // 상세작성 변경 없는 경우
+        if (noteUpdateReq.getIsDetail() == null) {
+            if (noteUpdateReq.getNose() != null) { this.nose = noteUpdateReq.getNose(); }
+            if (noteUpdateReq.getPalate() != null) { this.palate = noteUpdateReq.getPalate(); }
+            if (noteUpdateReq.getFinish() != null) { this.finish = noteUpdateReq.getFinish(); }
+        }
     }
 }

--- a/src/main/java/team_alcoholic/jumo_server/v2/note/dto/request/PurchaseNoteUpdateReq.java
+++ b/src/main/java/team_alcoholic/jumo_server/v2/note/dto/request/PurchaseNoteUpdateReq.java
@@ -1,0 +1,20 @@
+package team_alcoholic.jumo_server.v2.note.dto.request;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Getter @Setter
+public class PurchaseNoteUpdateReq {
+
+    private List<MultipartFile> noteImages;
+
+    private LocalDate purchaseAt;
+    private String place;
+    private Integer price;
+    private Integer volume;
+    private String content;
+}

--- a/src/main/java/team_alcoholic/jumo_server/v2/note/dto/request/TastingNoteUpdateReq.java
+++ b/src/main/java/team_alcoholic/jumo_server/v2/note/dto/request/TastingNoteUpdateReq.java
@@ -1,0 +1,31 @@
+package team_alcoholic.jumo_server.v2.note.dto.request;
+
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Getter @Setter
+public class TastingNoteUpdateReq {
+
+    private List<MultipartFile> noteImages;
+
+    private LocalDate tastingAt;
+    private String method;
+    private String place;
+    private List<Long> noteAromas;
+    private Integer score;
+    private Boolean isDetail;
+
+    @Size(max = 1500)
+    private String content;
+    @Size(max = 1500)
+    private String nose;
+    @Size(max = 1500)
+    private String palate;
+    @Size(max = 1500)
+    private String finish;
+}

--- a/src/main/java/team_alcoholic/jumo_server/v2/note/dto/response/GeneralNoteRes.java
+++ b/src/main/java/team_alcoholic/jumo_server/v2/note/dto/response/GeneralNoteRes.java
@@ -9,6 +9,7 @@ import team_alcoholic.jumo_server.v2.note.domain.TastingNote;
 
 @Getter @Setter
 public class GeneralNoteRes {
+
     private String type;
     private PurchaseNoteRes purchaseNote;
     private TastingNoteRes tastingNote;

--- a/src/main/java/team_alcoholic/jumo_server/v2/note/dto/response/NoteListRes.java
+++ b/src/main/java/team_alcoholic/jumo_server/v2/note/dto/response/NoteListRes.java
@@ -1,0 +1,23 @@
+package team_alcoholic.jumo_server.v2.note.dto.response;
+
+import lombok.Getter;
+import lombok.Setter;
+import team_alcoholic.jumo_server.v2.note.domain.Note;
+
+import java.util.List;
+
+@Getter @Setter
+public class NoteListRes {
+
+    private Long cursor;
+    private boolean eof;
+    private List<GeneralNoteRes> notes;
+
+    public static NoteListRes of(Long cursor, boolean eof, List<GeneralNoteRes> notes) {
+        NoteListRes noteListRes = new NoteListRes();
+        noteListRes.cursor = cursor;
+        noteListRes.eof = eof;
+        noteListRes.notes = notes;
+        return noteListRes;
+    }
+}

--- a/src/main/java/team_alcoholic/jumo_server/v2/note/repository/NoteRepository.java
+++ b/src/main/java/team_alcoholic/jumo_server/v2/note/repository/NoteRepository.java
@@ -1,10 +1,12 @@
 package team_alcoholic.jumo_server.v2.note.repository;
 
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import team_alcoholic.jumo_server.v2.note.domain.Note;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface NoteRepository extends JpaRepository<Note, Long> {
@@ -16,4 +18,21 @@ public interface NoteRepository extends JpaRepository<Note, Long> {
     @EntityGraph(attributePaths = {"user", "liquor", "noteImages"})
     @Query("select n from Note n where n.id=:id")
     Optional<Note> findDetailById(Long id);
+
+    /**
+     * 최신순 노트 페이지네이션 조회
+     * @param cursor 마지막으로 조회한 노트의 id
+     * @param pageable paging
+     */
+    @EntityGraph(attributePaths = {"user", "liquor", "noteImages"})
+    @Query("select n from Note n where n.id < :cursor order by n.id desc")
+    List<Note> findListByCursor(Long cursor, Pageable pageable);
+
+    /**
+     * 최신순 노트 페이지네이션 조회
+     * @param pageable paging
+     */
+    @EntityGraph(attributePaths = {"user", "liquor", "noteImages"})
+    @Query("select n from Note n order by n.id desc")
+    List<Note> findList(Pageable pageable);
 }

--- a/src/main/java/team_alcoholic/jumo_server/v2/note/repository/NoteRepository.java
+++ b/src/main/java/team_alcoholic/jumo_server/v2/note/repository/NoteRepository.java
@@ -4,7 +4,9 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import team_alcoholic.jumo_server.v1.liquor.domain.Liquor;
 import team_alcoholic.jumo_server.v2.note.domain.Note;
+import team_alcoholic.jumo_server.v2.user.domain.NewUser;
 
 import java.util.List;
 import java.util.Optional;
@@ -35,4 +37,12 @@ public interface NoteRepository extends JpaRepository<Note, Long> {
     @EntityGraph(attributePaths = {"user", "liquor", "noteImages"})
     @Query("select n from Note n order by n.id desc")
     List<Note> findList(Pageable pageable);
+
+    @EntityGraph(attributePaths = {"user", "liquor", "noteImages"})
+    @Query("select n from Note n where n.user = :user order by n.id desc")
+    List<Note> findListByUser(NewUser user);
+
+    @EntityGraph(attributePaths = {"user", "liquor", "noteImages"})
+    @Query("select n from Note n where n.liquor = :liquor order by n.id desc")
+    List<Note> findListByLiquor(Liquor liquor);
 }

--- a/src/main/java/team_alcoholic/jumo_server/v2/note/repository/PurchaseNoteRepository.java
+++ b/src/main/java/team_alcoholic/jumo_server/v2/note/repository/PurchaseNoteRepository.java
@@ -1,7 +1,30 @@
 package team_alcoholic.jumo_server.v2.note.repository;
 
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import team_alcoholic.jumo_server.v2.note.domain.Note;
 import team_alcoholic.jumo_server.v2.note.domain.PurchaseNote;
 
+import java.util.List;
+
 public interface PurchaseNoteRepository extends JpaRepository<PurchaseNote, Long> {
+
+    /**
+     * 최신순 노트 페이지네이션 조회
+     * @param cursor 마지막으로 조회한 노트의 id
+     * @param pageable paging
+     */
+    @EntityGraph(attributePaths = {"user", "liquor", "noteImages"})
+    @Query("select pn from PurchaseNote pn where pn.id < :cursor order by pn.id desc")
+    List<Note> findListByCursor(Long cursor, Pageable pageable);
+
+    /**
+     * 최신순 노트 페이지네이션 조회
+     * @param pageable paging
+     */
+    @EntityGraph(attributePaths = {"user", "liquor", "noteImages"})
+    @Query("select pn from PurchaseNote pn order by pn.id desc")
+    List<Note> findList(Pageable pageable);
 }

--- a/src/main/java/team_alcoholic/jumo_server/v2/note/repository/TastingNoteRepository.java
+++ b/src/main/java/team_alcoholic/jumo_server/v2/note/repository/TastingNoteRepository.java
@@ -1,7 +1,30 @@
 package team_alcoholic.jumo_server.v2.note.repository;
 
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import team_alcoholic.jumo_server.v2.note.domain.Note;
 import team_alcoholic.jumo_server.v2.note.domain.TastingNote;
 
+import java.util.List;
+
 public interface TastingNoteRepository extends JpaRepository<TastingNote, Long> {
+
+    /**
+     * 최신순 노트 페이지네이션 조회
+     * @param cursor 마지막으로 조회한 노트의 id
+     * @param pageable paging
+     */
+    @EntityGraph(attributePaths = {"user", "liquor", "noteImages"})
+    @Query("select tn from tasting_note_new tn where tn.id < :cursor order by tn.id desc")
+    List<Note> findListByCursor(Long cursor, Pageable pageable);
+
+    /**
+     * 최신순 노트 페이지네이션 조회
+     * @param pageable paging
+     */
+    @EntityGraph(attributePaths = {"user", "liquor", "noteImages"})
+    @Query("select tn from tasting_note_new tn order by tn.id desc")
+    List<Note> findList(Pageable pageable);
 }

--- a/src/main/java/team_alcoholic/jumo_server/v2/note/service/NoteService.java
+++ b/src/main/java/team_alcoholic/jumo_server/v2/note/service/NoteService.java
@@ -195,6 +195,10 @@ public class NoteService {
         return NoteListRes.of(newCursor, eof, noteResList);
     }
 
+    /**
+     * 사용자별 노트 조회 메서드
+     * @param userUuid 사용자 uuid
+     */
     public List<GeneralNoteRes> getNotesByUser(UUID userUuid) {
         // user 조회
         NewUser user = userRepository.findByUserUuid(userUuid);
@@ -212,6 +216,10 @@ public class NoteService {
         return noteResList;
     }
 
+    /**
+     * 주류별 노트 조회 메서드
+     * @param liquorId 주류 id
+     */
     public List<GeneralNoteRes> getNotesByLiquor(Long liquorId) {
         // liquor 조회
         Liquor liquor = liquorRepository.findById(liquorId)

--- a/src/main/java/team_alcoholic/jumo_server/v2/user/exception/UserNotFoundException.java
+++ b/src/main/java/team_alcoholic/jumo_server/v2/user/exception/UserNotFoundException.java
@@ -3,8 +3,15 @@ package team_alcoholic.jumo_server.v2.user.exception;
 
 import team_alcoholic.jumo_server.global.error.exception.NotFoundException;
 
+import java.util.UUID;
+
 public class UserNotFoundException extends NotFoundException {
+
     public UserNotFoundException(Long id) {
         super("해당하는 아이디의 유저를 찾지 못함 id: " + id);
+    }
+
+    public UserNotFoundException(UUID uuid) {
+        super("해당하는 아이디의 유저를 찾지 못함 uuid: " + uuid);
     }
 }


### PR DESCRIPTION
## 🚀 Jira 티켓
**[BYOB-221]**

<br>

## 🔨 작업 사항 

### 1. 노트 페이지네이션 조회 API
서비스 전체 노트 통합 조회, 구매 노트 조회, 감상 노트 조회 API를 구현함. 이전 모임 조회 API와 같이 커서 페이지네이션 방식으로 구현하였고, 조회 시 db에서 `limit + 1`개씩 조회하여 eof 여부를 함께 체크하도록 구현함.
- `GET /notes`
- `GET /notes/purchase`
- `GET /notes/tasting`

### 2. 사용자별/주류별 노트 조회 API
사용자별 노트 조회, 주류별 노트 조회 API를 구현함.
- `GET /notes/user/{userId}`
- `GET /notes/liquor/{liquorId}`

### 3. 노트 수정 API
노트 수정 API를 일부 구현함. 노트 수정 시 Note 자체 수정 처리 로직만 구현했고, NoteImage 및 NoteAroma에 대한 수정 처리 로직은 아직 구현하지 않음.
- `PUT /notes/purchase/{noteId}`
- `PUT /notes/tasting/{noteId}`

[BYOB-221]: https://swm-alcoholic.atlassian.net/browse/BYOB-221?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
  - 구매 및 시음 노트를 업데이트하는 새로운 API 엔드포인트 추가.
  - 사용자 및 주류 ID에 따라 노트를 검색하는 기능 추가.
  - 노트 목록을 페이지네이션하여 가져오는 기능 추가.

- **버그 수정**
  - 사용자 ID와 UUID 모두를 처리할 수 있도록 사용자 찾기 예외 처리 개선.

- **문서화**
  - 새로운 메서드에 대한 문서화 추가 및 기존 메서드 문서 업데이트.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->