### PR TITLE
[BYOB-232] 구매 노트 및 감상 노트 목록 조회 시 발생하는 N+1 문제 해결

### DIFF
--- a/src/main/java/team_alcoholic/jumo_server/v2/liquor/dto/LiquorSimpleRes.java
+++ b/src/main/java/team_alcoholic/jumo_server/v2/liquor/dto/LiquorSimpleRes.java
@@ -1,0 +1,31 @@
+package team_alcoholic.jumo_server.v2.liquor.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+import team_alcoholic.jumo_server.v2.liquor.domain.NewLiquor;
+
+/**
+ *
+ */
+@Getter @Setter
+public class LiquorSimpleRes {
+    private Long id;
+    private String koName;
+    private String enName;
+    private String thumbnailImageUrl;
+    private String type;
+    private String abv;
+//    private LiquorCategoryRes category;
+
+    public static LiquorSimpleRes from(NewLiquor liquor) {
+        LiquorSimpleRes dto = new LiquorSimpleRes();
+        dto.setId(liquor.getId());
+        dto.setKoName(liquor.getKoName());
+        dto.setEnName(liquor.getEnName());
+        dto.setThumbnailImageUrl(liquor.getThumbnailImageUrl());
+        dto.setType(liquor.getType());
+        dto.setAbv(liquor.getAbv());
+
+        return dto;
+    }
+}

--- a/src/main/java/team_alcoholic/jumo_server/v2/note/domain/Note.java
+++ b/src/main/java/team_alcoholic/jumo_server/v2/note/domain/Note.java
@@ -4,6 +4,7 @@ import jakarta.persistence.*;
 import lombok.Getter;
 import team_alcoholic.jumo_server.v1.liquor.domain.Liquor;
 import team_alcoholic.jumo_server.global.common.domain.BaseTimeEntity;
+import team_alcoholic.jumo_server.v2.liquor.domain.NewLiquor;
 import team_alcoholic.jumo_server.v2.user.domain.NewUser;
 
 import java.util.ArrayList;
@@ -25,13 +26,13 @@ public abstract class Note extends BaseTimeEntity {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "liquor_id")
-    private Liquor liquor;
+    private NewLiquor liquor;
 
     @OneToMany(mappedBy = "note", fetch = FetchType.LAZY)
     private List<NoteImage> noteImages = new ArrayList<>();
 
     protected Note() {}
-    public Note(NewUser user, Liquor liquor) {
+    public Note(NewUser user, NewLiquor liquor) {
         this.user = user;
         this.liquor = liquor;
     }

--- a/src/main/java/team_alcoholic/jumo_server/v2/note/domain/Note.java
+++ b/src/main/java/team_alcoholic/jumo_server/v2/note/domain/Note.java
@@ -2,7 +2,7 @@ package team_alcoholic.jumo_server.v2.note.domain;
 
 import jakarta.persistence.*;
 import lombok.Getter;
-import team_alcoholic.jumo_server.v1.liquor.domain.Liquor;
+import org.hibernate.annotations.BatchSize;
 import team_alcoholic.jumo_server.global.common.domain.BaseTimeEntity;
 import team_alcoholic.jumo_server.v2.liquor.domain.NewLiquor;
 import team_alcoholic.jumo_server.v2.user.domain.NewUser;
@@ -29,6 +29,7 @@ public abstract class Note extends BaseTimeEntity {
     private NewLiquor liquor;
 
     @OneToMany(mappedBy = "note", fetch = FetchType.LAZY)
+    @BatchSize(size = 100)
     private List<NoteImage> noteImages = new ArrayList<>();
 
     protected Note() {}

--- a/src/main/java/team_alcoholic/jumo_server/v2/note/domain/PurchaseNote.java
+++ b/src/main/java/team_alcoholic/jumo_server/v2/note/domain/PurchaseNote.java
@@ -4,6 +4,7 @@ import jakarta.persistence.DiscriminatorValue;
 import jakarta.persistence.Entity;
 import lombok.Getter;
 import team_alcoholic.jumo_server.v1.liquor.domain.Liquor;
+import team_alcoholic.jumo_server.v2.liquor.domain.NewLiquor;
 import team_alcoholic.jumo_server.v2.note.dto.request.PurchaseNoteCreateReq;
 import team_alcoholic.jumo_server.v2.note.dto.request.PurchaseNoteUpdateReq;
 import team_alcoholic.jumo_server.v2.user.domain.NewUser;
@@ -22,7 +23,7 @@ public class PurchaseNote extends Note {
     private String content;
 
     protected PurchaseNote() {}
-    public PurchaseNote(PurchaseNoteCreateReq noteCreateReq, NewUser user, Liquor liquor) {
+    public PurchaseNote(PurchaseNoteCreateReq noteCreateReq, NewUser user, NewLiquor liquor) {
         super(user, liquor);
         this.purchaseAt = noteCreateReq.getPurchaseAt();
         this.place = noteCreateReq.getPlace();

--- a/src/main/java/team_alcoholic/jumo_server/v2/note/domain/TastingNote.java
+++ b/src/main/java/team_alcoholic/jumo_server/v2/note/domain/TastingNote.java
@@ -6,6 +6,7 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.OneToMany;
 import lombok.Getter;
 import team_alcoholic.jumo_server.v1.liquor.domain.Liquor;
+import team_alcoholic.jumo_server.v2.liquor.domain.NewLiquor;
 import team_alcoholic.jumo_server.v2.note.dto.request.TastingNoteCreateReq;
 import team_alcoholic.jumo_server.v2.note.dto.request.TastingNoteUpdateReq;
 import team_alcoholic.jumo_server.v2.user.domain.NewUser;
@@ -33,7 +34,7 @@ public class TastingNote extends Note {
     private List<NoteAroma> noteAromas = new ArrayList<>();
 
     protected TastingNote() {}
-    public TastingNote(TastingNoteCreateReq noteCreateReq, NewUser user, Liquor liquor) {
+    public TastingNote(TastingNoteCreateReq noteCreateReq, NewUser user, NewLiquor liquor) {
         super(user, liquor);
         this.tastingAt = noteCreateReq.getTastingAt();
         this.method = noteCreateReq.getMethod();

--- a/src/main/java/team_alcoholic/jumo_server/v2/note/domain/TastingNote.java
+++ b/src/main/java/team_alcoholic/jumo_server/v2/note/domain/TastingNote.java
@@ -5,7 +5,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.OneToMany;
 import lombok.Getter;
-import team_alcoholic.jumo_server.v1.liquor.domain.Liquor;
+import org.hibernate.annotations.BatchSize;
 import team_alcoholic.jumo_server.v2.liquor.domain.NewLiquor;
 import team_alcoholic.jumo_server.v2.note.dto.request.TastingNoteCreateReq;
 import team_alcoholic.jumo_server.v2.note.dto.request.TastingNoteUpdateReq;
@@ -31,6 +31,7 @@ public class TastingNote extends Note {
     private String finish;
 
     @OneToMany(mappedBy = "note", fetch = FetchType.LAZY)
+    @BatchSize(size = 100)
     private List<NoteAroma> noteAromas = new ArrayList<>();
 
     protected TastingNote() {}

--- a/src/main/java/team_alcoholic/jumo_server/v2/note/dto/response/NoteRes.java
+++ b/src/main/java/team_alcoholic/jumo_server/v2/note/dto/response/NoteRes.java
@@ -2,7 +2,7 @@ package team_alcoholic.jumo_server.v2.note.dto.response;
 
 import lombok.Getter;
 import lombok.Setter;
-import team_alcoholic.jumo_server.v1.liquor.dto.LiquorRes;
+import team_alcoholic.jumo_server.v2.liquor.dto.LiquorRes;
 import team_alcoholic.jumo_server.v2.user.dto.UserRes;
 
 import java.time.LocalDateTime;

--- a/src/main/java/team_alcoholic/jumo_server/v2/note/dto/response/NoteRes.java
+++ b/src/main/java/team_alcoholic/jumo_server/v2/note/dto/response/NoteRes.java
@@ -2,7 +2,7 @@ package team_alcoholic.jumo_server.v2.note.dto.response;
 
 import lombok.Getter;
 import lombok.Setter;
-import team_alcoholic.jumo_server.v2.liquor.dto.LiquorRes;
+import team_alcoholic.jumo_server.v2.liquor.dto.LiquorSimpleRes;
 import team_alcoholic.jumo_server.v2.user.dto.UserRes;
 
 import java.time.LocalDateTime;
@@ -17,6 +17,6 @@ public abstract class NoteRes {
     private LocalDateTime updatedAt;
 
     private UserRes user;
-    private LiquorRes liquor;
+    private LiquorSimpleRes liquor;
     private List<NoteImageRes> noteImages = new ArrayList<>();
 }

--- a/src/main/java/team_alcoholic/jumo_server/v2/note/dto/response/PurchaseNoteRes.java
+++ b/src/main/java/team_alcoholic/jumo_server/v2/note/dto/response/PurchaseNoteRes.java
@@ -1,9 +1,8 @@
 package team_alcoholic.jumo_server.v2.note.dto.response;
 
-import jakarta.persistence.DiscriminatorValue;
 import lombok.Getter;
 import lombok.Setter;
-import team_alcoholic.jumo_server.v2.liquor.dto.LiquorRes;
+import team_alcoholic.jumo_server.v2.liquor.dto.LiquorSimpleRes;
 import team_alcoholic.jumo_server.v2.note.domain.NoteImage;
 import team_alcoholic.jumo_server.v2.note.domain.PurchaseNote;
 import team_alcoholic.jumo_server.v2.user.dto.UserRes;
@@ -26,7 +25,7 @@ public class PurchaseNoteRes extends NoteRes {
         purchaseNoteRes.setCreatedAt(note.getCreatedAt());
         purchaseNoteRes.setUpdatedAt(note.getUpdatedAt());
         purchaseNoteRes.setUser(UserRes.from(note.getUser()));
-        purchaseNoteRes.setLiquor(LiquorRes.from(note.getLiquor()));
+        purchaseNoteRes.setLiquor(LiquorSimpleRes.from(note.getLiquor()));
         for (NoteImage noteImage : note.getNoteImages()) {
             purchaseNoteRes.getNoteImages().add(NoteImageRes.from(noteImage));
         }

--- a/src/main/java/team_alcoholic/jumo_server/v2/note/dto/response/PurchaseNoteRes.java
+++ b/src/main/java/team_alcoholic/jumo_server/v2/note/dto/response/PurchaseNoteRes.java
@@ -3,7 +3,7 @@ package team_alcoholic.jumo_server.v2.note.dto.response;
 import jakarta.persistence.DiscriminatorValue;
 import lombok.Getter;
 import lombok.Setter;
-import team_alcoholic.jumo_server.v1.liquor.dto.LiquorRes;
+import team_alcoholic.jumo_server.v2.liquor.dto.LiquorRes;
 import team_alcoholic.jumo_server.v2.note.domain.NoteImage;
 import team_alcoholic.jumo_server.v2.note.domain.PurchaseNote;
 import team_alcoholic.jumo_server.v2.user.dto.UserRes;

--- a/src/main/java/team_alcoholic/jumo_server/v2/note/dto/response/TastingNoteRes.java
+++ b/src/main/java/team_alcoholic/jumo_server/v2/note/dto/response/TastingNoteRes.java
@@ -3,7 +3,7 @@ package team_alcoholic.jumo_server.v2.note.dto.response;
 import jakarta.persistence.DiscriminatorValue;
 import lombok.Getter;
 import lombok.Setter;
-import team_alcoholic.jumo_server.v1.liquor.dto.LiquorRes;
+import team_alcoholic.jumo_server.v2.liquor.dto.LiquorRes;
 import team_alcoholic.jumo_server.v2.aroma.dto.AromaRes;
 import team_alcoholic.jumo_server.v2.note.domain.NoteAroma;
 import team_alcoholic.jumo_server.v2.note.domain.NoteImage;

--- a/src/main/java/team_alcoholic/jumo_server/v2/note/dto/response/TastingNoteRes.java
+++ b/src/main/java/team_alcoholic/jumo_server/v2/note/dto/response/TastingNoteRes.java
@@ -1,10 +1,9 @@
 package team_alcoholic.jumo_server.v2.note.dto.response;
 
-import jakarta.persistence.DiscriminatorValue;
 import lombok.Getter;
 import lombok.Setter;
-import team_alcoholic.jumo_server.v2.liquor.dto.LiquorRes;
 import team_alcoholic.jumo_server.v2.aroma.dto.AromaRes;
+import team_alcoholic.jumo_server.v2.liquor.dto.LiquorSimpleRes;
 import team_alcoholic.jumo_server.v2.note.domain.NoteAroma;
 import team_alcoholic.jumo_server.v2.note.domain.NoteImage;
 import team_alcoholic.jumo_server.v2.note.domain.TastingNote;
@@ -35,7 +34,7 @@ public class TastingNoteRes extends NoteRes{
         tastingNoteRes.setCreatedAt(note.getCreatedAt());
         tastingNoteRes.setUpdatedAt(note.getUpdatedAt());
         tastingNoteRes.setUser(UserRes.from(note.getUser()));
-        tastingNoteRes.setLiquor(LiquorRes.from(note.getLiquor()));
+        tastingNoteRes.setLiquor(LiquorSimpleRes.from(note.getLiquor()));
         for (NoteImage noteImage : note.getNoteImages()) {
             tastingNoteRes.getNoteImages().add(NoteImageRes.from(noteImage));
         }

--- a/src/main/java/team_alcoholic/jumo_server/v2/note/repository/NoteRepository.java
+++ b/src/main/java/team_alcoholic/jumo_server/v2/note/repository/NoteRepository.java
@@ -5,6 +5,7 @@ import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import team_alcoholic.jumo_server.v1.liquor.domain.Liquor;
+import team_alcoholic.jumo_server.v2.liquor.domain.NewLiquor;
 import team_alcoholic.jumo_server.v2.note.domain.Note;
 import team_alcoholic.jumo_server.v2.user.domain.NewUser;
 
@@ -52,7 +53,7 @@ public interface NoteRepository extends JpaRepository<Note, Long> {
      */
     @EntityGraph(attributePaths = {"user", "liquor", "noteImages"})
     @Query("select n from Note n left join fetch n.noteImages ni where n.liquor = :liquor order by n.id desc, ni.id")
-    List<Note> findListByLiquor(Liquor liquor);
+    List<Note> findListByLiquor(NewLiquor liquor);
 
     /**
      * 사용자별 주류별 노트 조회
@@ -61,5 +62,5 @@ public interface NoteRepository extends JpaRepository<Note, Long> {
      */
     @EntityGraph(attributePaths = {"user", "liquor", "noteImages"})
     @Query("select n from Note n left join fetch n.noteImages ni where n.user = :user and n.liquor = :liquor order by n.id desc, ni.id")
-    List<Note> findListByUserAndLiquor(NewUser user, Liquor liquor);
+    List<Note> findListByUserAndLiquor(NewUser user, NewLiquor liquor);
 }

--- a/src/main/java/team_alcoholic/jumo_server/v2/note/repository/TastingNoteRepository.java
+++ b/src/main/java/team_alcoholic/jumo_server/v2/note/repository/TastingNoteRepository.java
@@ -16,7 +16,7 @@ public interface TastingNoteRepository extends JpaRepository<TastingNote, Long> 
      * @param cursor 마지막으로 조회한 노트의 id
      * @param pageable paging
      */
-    @EntityGraph(attributePaths = {"user", "liquor", "noteImages"})
+    @EntityGraph(attributePaths = {"user", "liquor", "noteAromas.aroma"})
     @Query("select tn from tasting_note_new tn where tn.id < :cursor order by tn.id desc")
     List<Note> findListByCursor(Long cursor, Pageable pageable);
 
@@ -24,7 +24,7 @@ public interface TastingNoteRepository extends JpaRepository<TastingNote, Long> 
      * 최신순 노트 페이지네이션 조회
      * @param pageable paging
      */
-    @EntityGraph(attributePaths = {"user", "liquor", "noteImages"})
+    @EntityGraph(attributePaths = {"user", "liquor", "noteAromas.aroma"})
     @Query("select tn from tasting_note_new tn order by tn.id desc")
     List<Note> findList(Pageable pageable);
 }

--- a/src/main/java/team_alcoholic/jumo_server/v2/note/service/NoteService.java
+++ b/src/main/java/team_alcoholic/jumo_server/v2/note/service/NoteService.java
@@ -10,7 +10,8 @@ import team_alcoholic.jumo_server.global.common.service.CommonUtilService;
 import team_alcoholic.jumo_server.global.error.exception.UnauthorizedException;
 import team_alcoholic.jumo_server.v1.liquor.domain.Liquor;
 import team_alcoholic.jumo_server.v1.liquor.exception.LiquorNotFoundException;
-import team_alcoholic.jumo_server.v1.liquor.repository.LiquorRepository;
+import team_alcoholic.jumo_server.v2.liquor.domain.NewLiquor;
+import team_alcoholic.jumo_server.v2.liquor.repository.NewLiquorRepository;
 import team_alcoholic.jumo_server.v2.aroma.domain.Aroma;
 import team_alcoholic.jumo_server.v2.aroma.repository.AromaRepository;
 import team_alcoholic.jumo_server.v2.note.domain.*;
@@ -42,7 +43,7 @@ public class NoteService {
     private final PurchaseNoteRepository purchaseNoteRepository;
     private final TastingNoteRepository tastingNoteRepository;
     private final UserRepository userRepository;
-    private final LiquorRepository liquorRepository;
+    private final NewLiquorRepository liquorRepository;
     private final AromaRepository aromaRepository;
     private final NoteImageRepository noteImageRepository;
     private final NoteAromaRepository noteAromaRepository;
@@ -57,7 +58,7 @@ public class NoteService {
     public PurchaseNoteRes createPurchaseNote(UUID userUuid, PurchaseNoteCreateReq noteCreateReq) throws IOException {
         // PurchaseNote 엔티티 생성 및 저장
         NewUser user = userRepository.findByUserUuid(userUuid);
-        Liquor liquor = liquorRepository.findById(noteCreateReq.getLiquorId())
+        NewLiquor liquor = liquorRepository.findById(noteCreateReq.getLiquorId())
             .orElseThrow(() -> new LiquorNotFoundException(noteCreateReq.getLiquorId()));
         PurchaseNote purchaseNote = new PurchaseNote(noteCreateReq, user, liquor);
         purchaseNoteRepository.save(purchaseNote);
@@ -84,7 +85,7 @@ public class NoteService {
     public TastingNoteRes createTastingNote(UUID userUuid, TastingNoteCreateReq noteCreateReq) throws IOException {
         // TastingNote 엔티티 생성 및 저장
         NewUser user = userRepository.findByUserUuid(userUuid);
-        Liquor liquor = liquorRepository.findById(noteCreateReq.getLiquorId())
+        NewLiquor liquor = liquorRepository.findById(noteCreateReq.getLiquorId())
             .orElseThrow(() -> new LiquorNotFoundException(noteCreateReq.getLiquorId()));
         TastingNote tastingNote = new TastingNote(noteCreateReq, user, liquor);
         tastingNoteRepository.save(tastingNote);
@@ -233,7 +234,7 @@ public class NoteService {
         if (user == null) { throw new UserNotFoundException(userUuid); }
 
         // liquor 조회
-        Liquor liquor = liquorRepository.findById(liquorId).orElseThrow(() -> new LiquorNotFoundException(liquorId));
+        NewLiquor liquor = liquorRepository.findById(liquorId).orElseThrow(() -> new LiquorNotFoundException(liquorId));
 
         // note 조회
         List<Note> notes = noteRepository.findListByUserAndLiquor(user, liquor);
@@ -253,7 +254,7 @@ public class NoteService {
      */
     public List<GeneralNoteRes> getNotesByLiquor(Long liquorId) {
         // liquor 조회
-        Liquor liquor = liquorRepository.findById(liquorId)
+        NewLiquor liquor = liquorRepository.findById(liquorId)
             .orElseThrow(() -> new LiquorNotFoundException(liquorId));
 
         // note 조회


### PR DESCRIPTION
## 🚀 Jira 티켓
**[BYOB-232]**

<br>

## 🔨 작업 배경

특정 API에서 심각한 N+1 문제가 발생했습니다. 다음 API에서 피드나 마이페이지에서 노트 목록을 조회할 때 여러 단계에 걸친 N+1 문제가 발생하는 것을 확인했습니다.

- `GET v2/notes`
- `GET v2/notes/purchase`
- `GET v2/notes/tasting`
- `GET v2/notes/user/{userUuid}`

## 💡 원인

주요 원인을 다음과 같이 짚어보았습니다. 기본적으로 엔티티들이 다음과 같이 깊은 연관관계를 가지고 있는 상황에서, 이를 적절하게 처리하지 않아 발생한 문제였습니다.
- `Note - NoteAroma`
- `Note - NoteAroma - Aroma`
- `Note - Liquor - AITastingNote`
- `Note - Liquor - User`

**잘못된 response dto 사용**
해당 API에서 굳이 필요없는 필드까지 가지고 있는 response dto를 사용했기 때문에, 불필요한 연관관계 지연 로딩이 추가적으로 발생함

**잘못된 jpql 작성**
인접한 연관관계에 대해서는 fetch join을 수행했지만, 더 깊은 연관관계에 대해서는 fetch join을 수행하지 않음

## 🌵 해결 과정

### 1. 연관 엔티티 버전 변경

`Note` 엔티티에 연관된 `Liquor` 엔티티 필드를 v1에서 v2로 변경해서, 불필요한 `AITastingNote` 엔티티 연관관계를 제거했습니다.

### 2. Response DTO 변경

기존 `NoteRes` dto에서 사용하던 `LiquorRes` dto에 불필요한 연관관계가 포함되어 있었기 때문에, 필요한 필드만 가지고 있는 `LiquorSimpleRes` dto를 새로 구현했습니다.

### 3. JPQL 변경

필요한 연관관계에 대해서 더 깊은 fetch join을 수행하도록 JPQL을 수정했습니다.
이때 3번 과정에서 다시 다음과 같은 문제가 추가적으로 발생했습니다.

### MultipleBagFetchException 발생

`TastingNote` 엔티티 목록을 조회하는 JPQL에서, `EntityGraph`의 `attributePaths`에 1:N 관계의 엔티티 컬렉션 필드인 `NoteImages`와 `NoteAromas`를 함께 명시했더니 `MultipleBagFetchException`이 발생했습니다.

따라서 `EntityGraph` 대신 해당 필드에 `BatchSize`를 설정하여 해결했습니다.

```java
@OneToMany(mappedBy = "note", fetch = FetchType.LAZY)
@BatchSize(size = 100)
private List<NoteImage> noteImages = new ArrayList<>();

@OneToMany(mappedBy = "note", fetch = FetchType.LAZY)
@BatchSize(size = 100)
private List<NoteAroma> noteAromas = new ArrayList<>();
```

### 엔티티 상속 구조로 인한 문제

`Note` 엔티티 목록을 조회하는 JPQL에서, 자식 엔티티 중 `TastingNote`만 가지고 있는 연관관계인 `NoteAromas`에 대한 fetch join이 불가능한 문제가 발생했습니다.
→ 해당 문제는 이후 작업을 통해 해결할 예정




[BYOB-232]: https://swm-alcoholic.atlassian.net/browse/BYOB-232?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ