### PR TITLE
[BYOB-233] 전체 노트 조회 시 발생하는 상속 구조 엔티티에서의 N+1 문제 해결

### DIFF
--- a/src/main/java/team_alcoholic/jumo_server/v2/note/domain/Note.java
+++ b/src/main/java/team_alcoholic/jumo_server/v2/note/domain/Note.java
@@ -29,7 +29,7 @@ public abstract class Note extends BaseTimeEntity {
     private NewLiquor liquor;
 
     @OneToMany(mappedBy = "note", fetch = FetchType.LAZY)
-    @BatchSize(size = 100)
+    @BatchSize(size = 20)
     private List<NoteImage> noteImages = new ArrayList<>();
 
     protected Note() {}

--- a/src/main/java/team_alcoholic/jumo_server/v2/note/domain/TastingNote.java
+++ b/src/main/java/team_alcoholic/jumo_server/v2/note/domain/TastingNote.java
@@ -31,7 +31,7 @@ public class TastingNote extends Note {
     private String finish;
 
     @OneToMany(mappedBy = "note", fetch = FetchType.LAZY)
-    @BatchSize(size = 100)
+    @BatchSize(size = 20)
     private List<NoteAroma> noteAromas = new ArrayList<>();
 
     protected TastingNote() {}

--- a/src/main/java/team_alcoholic/jumo_server/v2/note/repository/NoteRepository.java
+++ b/src/main/java/team_alcoholic/jumo_server/v2/note/repository/NoteRepository.java
@@ -4,7 +4,6 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
-import team_alcoholic.jumo_server.v1.liquor.domain.Liquor;
 import team_alcoholic.jumo_server.v2.liquor.domain.NewLiquor;
 import team_alcoholic.jumo_server.v2.note.domain.Note;
 import team_alcoholic.jumo_server.v2.user.domain.NewUser;
@@ -15,53 +14,35 @@ import java.util.Optional;
 public interface NoteRepository extends JpaRepository<Note, Long> {
 
     /**
-     * 노트 상세 조회
+     * 노트 단건 조회
      * @param id 노트 id
      */
-    @EntityGraph(attributePaths = {"user", "liquor", "noteImages"})
-    @Query("select n from Note n left join fetch n.noteImages ni where n.id=:id order by ni.id")
-    Optional<Note> findDetailById(Long id);
+    @Query("select n from Note n where n.id=:id")
+    Optional<Note> findById(Long id);
 
     /**
-     * 최신순 노트 페이지네이션 조회
-     * @param cursor 마지막으로 조회한 노트의 id
-     * @param pageable paging
-     */
-    @EntityGraph(attributePaths = {"user", "liquor", "noteImages"})
-    @Query("select n from Note n left join fetch n.noteImages ni where n.id < :cursor order by n.id desc, ni.id")
-    List<Note> findListByCursor(Long cursor, Pageable pageable);
-
-    /**
-     * 유형별 노트 상세 조회 전 간략한 목록 조회
      * 최신순 노트 페이지네이션 조회: 첫 페이지
+     * 유형별 노트 상세 조회 전 간략한 목록 조회
      * @param pageable paging
      */
     @Query("select n from Note n order by n.id desc")
-    List<Note> findSimpleList(Pageable pageable);
+    List<Note> findList(Pageable pageable);
 
     /**
-     * 유형별 노트 상세 조회 전 간략한 목록 조회
      * 최신순 노트 페이지네이션 조회
+     * 유형별 노트 상세 조회 전 간략한 목록 조회
      * @param cursor 마지막으로 조회한 노트의 id
      * @param pageable paging
      */
     @Query("select n from Note n where n.id < :cursor order by n.id desc")
-    List<Note> findSimpleListByCursor(Long cursor, Pageable pageable);
-
-    /**
-     * 최신순 노트 페이지네이션 조회: 첫 페이지
-     * @param pageable paging
-     */
-    @EntityGraph(attributePaths = {"user", "liquor", "noteImages"})
-    @Query("select n from Note n left join fetch n.noteImages ni order by n.id desc, ni.id")
-    List<Note> findList(Pageable pageable);
+    List<Note> findListByCursor(Long cursor, Pageable pageable);
 
     /**
      * 사용자별 노트 조회
+     * 유형별 노트 상세 조회 전 간략한 목록 조회
      * @param user 사용자
      */
-    @EntityGraph(attributePaths = {"user", "liquor", "noteImages"})
-    @Query("select n from Note n left join fetch n.noteImages ni where n.user = :user order by n.id desc, ni.id")
+    @Query("select n from Note n where n.user = :user order by n.id desc")
     List<Note> findListByUser(NewUser user);
 
     /**

--- a/src/main/java/team_alcoholic/jumo_server/v2/note/repository/NoteRepository.java
+++ b/src/main/java/team_alcoholic/jumo_server/v2/note/repository/NoteRepository.java
@@ -32,6 +32,23 @@ public interface NoteRepository extends JpaRepository<Note, Long> {
     List<Note> findListByCursor(Long cursor, Pageable pageable);
 
     /**
+     * 유형별 노트 상세 조회 전 간략한 목록 조회
+     * 최신순 노트 페이지네이션 조회: 첫 페이지
+     * @param pageable paging
+     */
+    @Query("select n from Note n order by n.id desc")
+    List<Note> findSimpleList(Pageable pageable);
+
+    /**
+     * 유형별 노트 상세 조회 전 간략한 목록 조회
+     * 최신순 노트 페이지네이션 조회
+     * @param cursor 마지막으로 조회한 노트의 id
+     * @param pageable paging
+     */
+    @Query("select n from Note n where n.id < :cursor order by n.id desc")
+    List<Note> findSimpleListByCursor(Long cursor, Pageable pageable);
+
+    /**
      * 최신순 노트 페이지네이션 조회: 첫 페이지
      * @param pageable paging
      */

--- a/src/main/java/team_alcoholic/jumo_server/v2/note/repository/PurchaseNoteRepository.java
+++ b/src/main/java/team_alcoholic/jumo_server/v2/note/repository/PurchaseNoteRepository.java
@@ -16,7 +16,7 @@ public interface PurchaseNoteRepository extends JpaRepository<PurchaseNote, Long
      * @param cursor 마지막으로 조회한 노트의 id
      * @param pageable paging
      */
-    @EntityGraph(attributePaths = {"user", "liquor", "noteImages"})
+    @EntityGraph(attributePaths = {"user", "liquor"})
     @Query("select pn from PurchaseNote pn where pn.id < :cursor order by pn.id desc")
     List<Note> findListByCursor(Long cursor, Pageable pageable);
 
@@ -24,7 +24,15 @@ public interface PurchaseNoteRepository extends JpaRepository<PurchaseNote, Long
      * 최신순 노트 페이지네이션 조회
      * @param pageable paging
      */
-    @EntityGraph(attributePaths = {"user", "liquor", "noteImages"})
+    @EntityGraph(attributePaths = {"user", "liquor"})
     @Query("select pn from PurchaseNote pn order by pn.id desc")
     List<Note> findList(Pageable pageable);
+
+    /**
+     * noteId 리스트로 구매 노트 리스트 조회
+     * @param idList noteId 리스트
+     */
+    @EntityGraph(attributePaths = {"user", "liquor", "noteImages"})
+    @Query("select pn from PurchaseNote pn left join fetch pn.noteImages ni where pn.id in :idList order by pn.id desc, ni.id")
+    List<PurchaseNote> findListByIdList(List<Long> idList);
 }

--- a/src/main/java/team_alcoholic/jumo_server/v2/note/repository/TastingNoteRepository.java
+++ b/src/main/java/team_alcoholic/jumo_server/v2/note/repository/TastingNoteRepository.java
@@ -5,6 +5,7 @@ import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import team_alcoholic.jumo_server.v2.note.domain.Note;
+import team_alcoholic.jumo_server.v2.note.domain.PurchaseNote;
 import team_alcoholic.jumo_server.v2.note.domain.TastingNote;
 
 import java.util.List;
@@ -27,4 +28,12 @@ public interface TastingNoteRepository extends JpaRepository<TastingNote, Long> 
     @EntityGraph(attributePaths = {"user", "liquor", "noteAromas.aroma"})
     @Query("select tn from tasting_note_new tn order by tn.id desc")
     List<Note> findList(Pageable pageable);
+
+    /**
+     * noteId 리스트로 테이스팅 노트 리스트 조회
+     * @param idList noteId 리스트
+     */
+    @EntityGraph(attributePaths = {"user", "liquor", "noteAromas.aroma"})
+    @Query("select tn from tasting_note_new tn where tn.id in :idList order by tn.id desc")
+    List<TastingNote> findListByIdList(List<Long> idList);
 }

--- a/src/main/java/team_alcoholic/jumo_server/v2/note/repository/TastingNoteRepository.java
+++ b/src/main/java/team_alcoholic/jumo_server/v2/note/repository/TastingNoteRepository.java
@@ -5,12 +5,20 @@ import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import team_alcoholic.jumo_server.v2.note.domain.Note;
-import team_alcoholic.jumo_server.v2.note.domain.PurchaseNote;
 import team_alcoholic.jumo_server.v2.note.domain.TastingNote;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface TastingNoteRepository extends JpaRepository<TastingNote, Long> {
+
+    /**
+     * noteId로 테이스팅 노트 조회
+     * @param id noteId
+     */
+    @EntityGraph(attributePaths = {"user", "liquor", "noteAromas.aroma"})
+    @Query("select tn from tasting_note_new tn where tn.id = :id order by tn.id desc")
+    Optional<TastingNote> findById(Long id);
 
     /**
      * 최신순 노트 페이지네이션 조회

--- a/src/main/java/team_alcoholic/jumo_server/v2/note/service/NoteService.java
+++ b/src/main/java/team_alcoholic/jumo_server/v2/note/service/NoteService.java
@@ -156,7 +156,15 @@ public class NoteService {
      */
     @Transactional
     public GeneralNoteRes getNoteById(Long id) {
-        Note note = noteRepository.findDetailById(id).orElseThrow(() -> new NoteNotFoundException(id));
+        // 부모 엔티티 Note로 먼저 조회
+        Note simpleNote = noteRepository.findById(id).orElseThrow(() -> new NoteNotFoundException(id));
+        String type = simpleNote.getClass().getAnnotation(DiscriminatorValue.class).value();
+
+        // 노트 유형에 맞게 상세 조회
+        Note note;
+        if ("PURCHASE".equals(type)) { note = purchaseNoteRepository.findById(simpleNote.getId()).orElseThrow(() -> new NoteNotFoundException(simpleNote.getId())); }
+        else { note = tastingNoteRepository.findById(simpleNote.getId()).orElseThrow(() -> new NoteNotFoundException(simpleNote.getId())); }
+
         return GeneralNoteRes.from(note);
     }
 


### PR DESCRIPTION
## 🚀 Jira 티켓
**[BYOB-233]**

<br>

# 🗿 배경 및 원인

JPQL N+1 문제를 해결하던 중 다음과 같은 추가적인 문제가 발생했습니다.
`Note` 엔티티 목록을 조회하는 JPQL에서, 자식 엔티티 중 `TastingNote`만 가지고 있는 연관관계인 `NoteAromas`에 대한 fetch join이 불가능한 문제가 발생했습니다.
부모 엔티티 타입으로 조회할 때, 공통 필드가 아닌 개별 자식 엔티티의 연관관계를 fetch join할 수 없어 발생하는 문제였습니다.

# 🌵 해결 과정

문제를 해결하기 위해 두 가지 방법을 사용할 수 있었습니다.
1. 상속 구조 자체를 풀어버리기: 상속 관계가 아닌 개별 엔티티로 PurchaseNote와 TastingNote를 분리
2. 상속 구조 내에서 온몸비틀기

### 상속 구조 자체를 풀어버리기

상속 구조를 제거하는 편이 개발 자체의 복잡도를 낮출 수 있다는 장점이 있었고, 실제로 멘토님께서도 실무에서 상속 구조를 잘 사용하지 않는다는 피드백을 주시기도 했습니다.
하지만 상속 구조를 제거하게 되면 운영중인 서비스의 테이블도 변경해야 한다는 문제점이 있었습니다.
따라서 이번 프로젝트 내에서는 상속 구조를 유지한 채로 해당 문제를 해결하기로 결정했습니다.

### 상속 구조 내에서 온몸비틀기

아래와 같은 흐름으로 쿼리 수를 최소화할 수 있었습니다.
1. 부모 엔티티인 `Note`에 대해 `noteId`와 `dtype`에 대해서만 페이지네이션 조회
2. `dtype`에 맞게 분류한 뒤 각각의 `dtype`에 대한 `noteId` 리스트로 in 절을 활용해서 자식 엔티티 조회
3. 가져온 각각의 리스트를 다시 noteId를 기준으로 하나의 리스트로 병합

Note에 대한 쿼리 1개 + PurchaseNote/TastingNote에 대한 쿼리 2개, 총 3개의 쿼리로 N+1 문제를 회피하도록 개선했습니다.

# 🛠️ 작업 사항

### 상속 구조 엔티티 N+1 해결 로직 구현

Note 엔티티에 대해 페이지네이션 조회를 수행한 리스트인 simpleNotes를 인자로 받아서, 개별 상세 조회 후 다시 하나의 리스트로 반환하는 getMergedChildNoteList 메서드 구현

노트 타입에 따라 리스트 분리

```java
List<Long> purchaseNotesIdList = new ArrayList<>();
List<Long> tastingNotesIdList = new ArrayList<>();
for (Note note : simpleNotes) {
    if ("PURCHASE".equals(note.getClass().getAnnotation(DiscriminatorValue.class).value())) {
        purchaseNotesIdList.add(note.getId());
    }
    else { tastingNotesIdList.add(note.getId()); }
}
```

노트 타입에 따라 개별 상세 조회

```java
List<PurchaseNote> purchaseNotes = (purchaseNotesIdList.isEmpty()) ?
	new ArrayList<>() :
	purchaseNoteRepository.findListByIdList(purchaseNotesIdList);
List<TastingNote> tastingNotes = (tastingNotesIdList.isEmpty()) ?
	new ArrayList<>() :
	tastingNoteRepository.findListByIdList(tastingNotesIdList);
```

분리된 리스트 통합 후 HashMap으로 변환

```java
// 분리된 리스트 다시 통합
List<Note> notes = new ArrayList<>();
notes.addAll(purchaseNotes);
notes.addAll(tastingNotes);

// 통합된 리스트 HashMap으로 변환
Map<Long, Note> results = new HashMap<>();
for (Note note : notes) {
    results.put(note.getId(), note);
}
```

simpleNotes의 순서에 맞게 HashMap에서 조회한 뒤, response 객체로 변환

```java
List<GeneralNoteRes> noteResList = new ArrayList<>();
for (Note simpleNote : simpleNotes) {
    Note note = results.get(simpleNote.getId());
    noteResList.add(GeneralNoteRes.from(note));
}
```

### 개선 사항

코드가 길고 복잡하기도 하고, 일부 비효율적인 로직이 존재하기 때문에 다른 방식으로의 구현을 고려해보려고 합니다.




[BYOB-233]: https://swm-alcoholic.atlassian.net/browse/BYOB-233?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- `TastingNote` 및 `Note`에 대한 새로운 메서드 추가로 단일 및 다중 노트 검색 기능 강화.
	- `PurchaseNote` 리스트 검색을 위한 새로운 메서드 추가.
- **Bug Fixes**
	- 배치 크기 조정으로 이미지 로딩 최적화.
- **Refactor**
	- 노트 검색 및 관리 로직 개선으로 코드 가독성 및 유지보수성 향상.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->